### PR TITLE
Fix Windows GUI lifecycle, persistence, and usage meters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tura_path",
 ]
 
 [[package]]

--- a/agents/Cargo.toml
+++ b/agents/Cargo.toml
@@ -20,6 +20,7 @@ required-features = ["business-tests"]
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+tura_path.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/agents/src/store.rs
+++ b/agents/src/store.rs
@@ -74,9 +74,18 @@ fn default_op_manual() -> bool {
 
 pub fn discover_agents(project_root: &Path) -> Vec<StoredAgent> {
     let mut agents = BTreeMap::<String, StoredAgent>::new();
+    discover_agents_at(project_root, &mut agents);
+    let writable_root = writable_project_root(project_root);
+    if writable_root != project_root {
+        discover_agents_at(&writable_root, &mut agents);
+    }
+    agents.into_values().collect()
+}
+
+fn discover_agents_at(project_root: &Path, agents: &mut BTreeMap<String, StoredAgent>) {
     let root = project_root.join(AGENTS_DIR);
     let Ok(entries) = fs::read_dir(&root) else {
-        return Vec::new();
+        return;
     };
     for entry in entries.flatten() {
         let path = entry.path();
@@ -85,10 +94,9 @@ pub fn discover_agents(project_root: &Path) -> Vec<StoredAgent> {
         }
         if let Some(agent) = load_agent_at(project_root, &path) {
             let key = agent.summary.id.to_ascii_lowercase();
-            agents.entry(key).or_insert(agent);
+            agents.insert(key, agent);
         }
     }
-    agents.into_values().collect()
 }
 
 pub fn load_agent(project_root: &Path, agent_id: &str) -> Option<StoredAgent> {
@@ -124,7 +132,8 @@ pub fn save_dynamic_agent(
     config: &AgentConfig,
     prompt: Option<&str>,
 ) -> Result<StoredAgent, String> {
-    let agent_dir = dynamic_agent_path(project_root, &config.agent_name)?;
+    let project_root = writable_project_root(project_root);
+    let agent_dir = dynamic_agent_path(&project_root, &config.agent_name)?;
     fs::create_dir_all(&agent_dir).map_err(|err| {
         format!(
             "failed to create agent directory {}: {err}",
@@ -133,7 +142,7 @@ pub fn save_dynamic_agent(
     })?;
 
     let mut config = config.clone();
-    config.agent_directory = path_relative_to(project_root, &agent_dir);
+    config.agent_directory = path_relative_to(&project_root, &agent_dir);
     if config.agent_prompt.is_empty() {
         config.agent_prompt.push(serde_json::json!({
             "agent_prompt": config.agent_name,
@@ -157,7 +166,7 @@ pub fn save_dynamic_agent(
             )
         })?;
     }
-    load_agent_at(project_root, &agent_dir)
+    load_agent_at(&project_root, &agent_dir)
         .ok_or_else(|| format!("failed to reload agent {}", config.agent_name))
 }
 
@@ -178,13 +187,23 @@ pub fn delete_dynamic_agent(project_root: &Path, agent_id: &str) -> Result<bool,
         }
         canonical_id = Some(agent.summary.id);
     }
-    let agent_dir = dynamic_agent_path(project_root, canonical_id.as_deref().unwrap_or(agent_id))?;
+    let writable_root = writable_project_root(project_root);
+    let agent_dir =
+        dynamic_agent_path(&writable_root, canonical_id.as_deref().unwrap_or(agent_id))?;
     if !agent_dir.exists() {
         return Ok(false);
     }
     fs::remove_dir_all(&agent_dir)
         .map_err(|err| format!("failed to delete agent {}: {err}", agent_dir.display()))?;
     Ok(true)
+}
+
+fn writable_project_root(project_root: &Path) -> PathBuf {
+    if tura_path::build_kind() == "release" {
+        tura_path::home_runtime_dir()
+    } else {
+        project_root.to_path_buf()
+    }
 }
 
 pub fn default_agent_config(project_root: &Path, agent_id: &str) -> Result<AgentConfig, String> {

--- a/apps/gui/app/src/conversation/conversation-view.tsx
+++ b/apps/gui/app/src/conversation/conversation-view.tsx
@@ -27,8 +27,9 @@ import {
   agentAvatarMedia,
   type AvatarDisplayMode,
 } from "../components/avatar/agent-avatar-canvas";
-import { t } from "../i18n";
+import { currentLanguage, t } from "../i18n";
 import { classNames, formatTime } from "../state/format";
+import { providerIdFromModel } from "../utils/settings";
 import {
   type AppState,
   type ComposerImage,
@@ -136,6 +137,20 @@ export function ConversationView(props: {
     ),
   );
   const latestStickerEmoji = createMemo(() => latestSticker(props.messages));
+  const contextTokens = createMemo(() => {
+    const tokens = props.session?.context_tokens;
+    if (!tokens || !Number.isFinite(tokens.limit) || tokens.limit <= 0) {
+      return;
+    }
+    const input = Math.min(Math.max(tokens.input, 0), tokens.limit);
+    return { input, limit: tokens.limit, percent: Math.round((input / tokens.limit) * 100) };
+  });
+  const providerUsage = createMemo(() =>
+    (providerIdFromModel(props.session?.model) ??
+      providerIdFromModel(props.state.selectedModel)) === "codex"
+      ? props.state.providerUsage
+      : undefined,
+  );
   const latestMessageId = createMemo(() => groupedMessages().at(-1)?.id);
   const latestMessageLiveSignature = createMemo(() => {
     const message = groupedMessages().at(-1);
@@ -413,6 +428,36 @@ export function ConversationView(props: {
           <span>{t("conversation")}</span>
           <h1>{props.session ? sessionTitle(props.session) : t("newSession")}</h1>
         </div>
+        <Show when={!props.compact && (contextTokens() || providerUsage())}>
+          <div class="usage-meters">
+            <Show when={contextTokens()} keyed>
+              {(tokens) => (
+                <div class="usage-meter">
+                  <span>{t("contextUsage")}</span>
+                  <span>{tokens.percent}%</span>
+                  <meter
+                    min={0}
+                    max={tokens.limit}
+                    value={tokens.input}
+                    aria-label={t("contextUsage")}
+                  />
+                </div>
+              )}
+            </Show>
+            <For each={providerUsage()?.windows ?? []}>
+              {(usage) => {
+                const label = providerUsageWindowLabel(usage.window_seconds);
+                return (
+                  <div class="usage-meter">
+                    <span>{label}</span>
+                    <span>{Math.round(usage.used_percent)}%</span>
+                    <meter min={0} max={100} value={usage.used_percent} aria-label={label} />
+                  </div>
+                );
+              }}
+            </For>
+          </div>
+        </Show>
       </header>
       <div class="conversation-grid page-layer-middle">
         <div
@@ -507,6 +552,23 @@ export function ConversationView(props: {
       </Show>
     </section>
   );
+}
+
+function providerUsageWindowLabel(windowSeconds?: number | null): string {
+  if (!windowSeconds || windowSeconds <= 0) return t("usageLimit");
+  const units: Array<["week" | "day" | "hour" | "minute" | "second", number]> = [
+    ["week", 604_800],
+    ["day", 86_400],
+    ["hour", 3_600],
+    ["minute", 60],
+    ["second", 1],
+  ];
+  const [unit, seconds] = units.find(([, seconds]) => windowSeconds % seconds === 0) ?? units[4];
+  return new Intl.NumberFormat(currentLanguage(), {
+    style: "unit",
+    unit,
+    unitDisplay: "long",
+  }).format(windowSeconds / seconds);
 }
 
 function Transcript(props: {

--- a/apps/gui/app/src/hooks/use-app-gateway-lifecycle.ts
+++ b/apps/gui/app/src/hooks/use-app-gateway-lifecycle.ts
@@ -41,6 +41,7 @@ function gatewayArray<T>(value: T[] | unknown): T[] {
 }
 
 const BOOTSTRAP_REQUEST_TIMEOUT_MS = 20_000;
+const PROVIDER_USAGE_REFRESH_MS = 60_000;
 
 export function useAppGatewayLifecycle(options: {
   state: Accessor<AppState>;
@@ -110,6 +111,21 @@ export function useAppGatewayLifecycle(options: {
     onCleanup(() => stream.close());
   });
 
+  createEffect(() => {
+    if (e2eFixture || connection() !== "connected") {
+      return;
+    }
+    const refresh = async () => {
+      const usage = await safe(() => rootClient().providerUsage("codex"), undefined);
+      if (usage) {
+        setState((previous) => ({ ...previous, providerUsage: usage }));
+      }
+    };
+    void refresh();
+    const timer = window.setInterval(refresh, PROVIDER_USAGE_REFRESH_MS);
+    onCleanup(() => window.clearInterval(timer));
+  });
+
   onMount(() => {
     if (!e2eFixture) {
       void hydrate();
@@ -125,15 +141,15 @@ export function useAppGatewayLifecycle(options: {
       error: undefined,
       gatewayStartupNotice: previous.gatewayStartupNotice,
     }));
-    if (!disableGatewayAutostart) {
-      const connected = await tryStartGateway(gatewayUrl(), gatewayUrlExplicit, setState);
-      if (!connected) {
-        throw new DOMException("Gateway is not running.", "TimeoutError");
-      }
-      await waitForGatewayHealth(gatewayUrl(), GATEWAY_HEALTH_TIMEOUT_MS, setState);
-    }
-    const client = rootClient();
     try {
+      if (!disableGatewayAutostart) {
+        const connected = await tryStartGateway(gatewayUrl(), gatewayUrlExplicit, setState);
+        if (!connected) {
+          throw new DOMException("Gateway is not running.", "TimeoutError");
+        }
+        await waitForGatewayHealth(gatewayUrl(), GATEWAY_HEALTH_TIMEOUT_MS, setState);
+      }
+      const client = rootClient();
       const fallbackPaths: NonNullable<AppState["paths"]> = {
         home: "",
         state: "",

--- a/apps/gui/app/src/i18n/en.ts
+++ b/apps/gui/app/src/i18n/en.ts
@@ -310,6 +310,8 @@ export const en = {
   providerSettings: "Provider settings",
   providers: "Providers",
   configureProvider: "Configure providers",
+  contextUsage: "Context",
+  usageLimit: "Usage",
   providerAuthRequired: "Provider needs authentication",
   providerCredential: "Provider credential",
   providerCredentialHint: "Configure OAuth or API token for this provider",

--- a/apps/gui/app/src/i18n/zh-CN.ts
+++ b/apps/gui/app/src/i18n/zh-CN.ts
@@ -326,6 +326,8 @@ export const zhCN = {
   providerSettings: "服务商配置",
   providers: "服务商",
   configureProvider: "配置服务商",
+  contextUsage: "上下文",
+  usageLimit: "用量",
   providerAuthRequired: "服务商需要重新认证",
   providerCredential: "服务商凭据",
   providerCredentialHint: "为当前服务商配置 OAuth 或 API Token",

--- a/apps/gui/app/src/state/global-store.ts
+++ b/apps/gui/app/src/state/global-store.ts
@@ -20,6 +20,7 @@ import type {
   ProviderAuthActionResponse,
   ProviderAuthMethod,
   ProviderAuthStatusResponse,
+  ProviderUsageResponse,
   ProviderListResponse,
   QuestionRequest,
   ServiceStatusResponse,
@@ -117,6 +118,7 @@ export type AppState = {
   modelConfig?: TuraConfigResponse;
   providerAuthMethods: Record<string, ProviderAuthMethod[]>;
   providerAuthStatus: Record<string, ProviderAuthStatusResponse>;
+  providerUsage?: ProviderUsageResponse;
   providerValidationReceipts: Record<string, ProviderAuthActionResponse>;
   agents: Agent[];
   personas: StoredPersona[];

--- a/apps/gui/app/src/styles/parts/base/page-shell.css
+++ b/apps/gui/app/src/styles/parts/base/page-shell.css
@@ -205,6 +205,45 @@
   white-space: nowrap;
 }
 
+.usage-meters {
+  display: grid;
+  gap: var(--space-2);
+  align-self: center;
+  width: 160px;
+}
+
+.usage-meter {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 5px var(--space-2);
+  color: var(--muted);
+  font-size: var(--font-small);
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-meter meter {
+  grid-column: 1 / -1;
+  width: 100%;
+  height: 6px;
+  overflow: hidden;
+  border: 0;
+  border-radius: 999px;
+  background: var(--wash);
+  appearance: none;
+}
+
+.usage-meter meter::-webkit-meter-bar {
+  border: 0;
+  border-radius: 999px;
+  background: var(--wash);
+}
+
+.usage-meter meter::-webkit-meter-optimum-value {
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 160ms ease;
+}
+
 .page-actions {
   display: flex;
   justify-content: flex-end;

--- a/apps/gui/app/src/styles/parts/responsive/desktop-tablet.css
+++ b/apps/gui/app/src/styles/parts/responsive/desktop-tablet.css
@@ -147,6 +147,10 @@
     padding-left: var(--page-title-offset);
   }
 
+  .conversation-view > .page-head .usage-meters {
+    margin-left: var(--page-title-offset);
+  }
+
   .main-tabs button,
   .workspace-row,
   .child-row {

--- a/apps/gui/sdk/gateway/src/client.ts
+++ b/apps/gui/sdk/gateway/src/client.ts
@@ -27,6 +27,7 @@ import type {
   ProviderAuthValidationInput,
   ProviderAuthMethod,
   ProviderAuthStatusResponse,
+  ProviderUsageResponse,
   ProductConfig,
   ProductAgent,
   ProductIssue,
@@ -319,6 +320,10 @@ export class GatewayClient {
 
   providerAuthStatus(providerId: string): Promise<ProviderAuthStatusResponse> {
     return this.get(`/provider/${encodeURIComponent(providerId)}/auth/status`);
+  }
+
+  providerUsage(providerId: string): Promise<ProviderUsageResponse | null> {
+    return this.get(`/provider/${encodeURIComponent(providerId)}/usage`);
   }
 
   setProviderAuth(providerId: string, payload: ProviderAuthInput): Promise<boolean> {

--- a/apps/gui/sdk/gateway/src/types/provider.ts
+++ b/apps/gui/sdk/gateway/src/types/provider.ts
@@ -88,6 +88,16 @@ export type ProviderAuthStatusResponse = {
   last_error_category?: string | null;
 };
 
+export type ProviderUsageWindow = {
+  used_percent: number;
+  resets_at?: number | null;
+  window_seconds?: number | null;
+};
+
+export type ProviderUsageResponse = {
+  windows: ProviderUsageWindow[];
+};
+
 export type ProviderAuthActionResponse = {
   ok: boolean;
   provider_id: string;

--- a/apps/gui/tests/unit/conversation/session-render-cache.test.ts
+++ b/apps/gui/tests/unit/conversation/session-render-cache.test.ts
@@ -89,4 +89,12 @@ describe("session render cache", () => {
       'data-agent-avatar-anchor={props.isLatestAssistant ? "" : undefined}',
     );
   });
+
+  test("conversation header shows live context fill from session metrics", () => {
+    expect(conversationSource).toContain("props.session?.context_tokens");
+    expect(conversationSource).toContain("<meter");
+    expect(conversationSource).toContain('aria-label={t("contextUsage")}');
+    expect(conversationSource).toContain("providerUsage()?.windows");
+    expect(conversationSource).toContain("providerUsageWindowLabel(usage.window_seconds)");
+  });
 });

--- a/apps/gui/tests/unit/gateway-lifecycle.test.ts
+++ b/apps/gui/tests/unit/gateway-lifecycle.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, expect, mock, test } from "bun:test";
+import * as solid from "../../app/node_modules/solid-js/dist/solid.js";
+
+mock.module("solid-js", () => solid);
+
+const { createRoot, createSignal } = solid;
+
+const originalFetch = globalThis.fetch;
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.window = originalWindow;
+});
+
+test("gateway startup failure exits the loading state", async () => {
+  const [{ useAppGatewayLifecycle }, { initialAppState }] = await Promise.all([
+    import("../../app/src/hooks/use-app-gateway-lifecycle"),
+    import("../../app/src/state/global-store"),
+  ]);
+  const [state, setState] = createSignal(initialAppState("http://127.0.0.1:65530"));
+  globalThis.window = globalThis as Window & typeof globalThis;
+  globalThis.fetch = (async () => {
+    throw new TypeError("Failed to fetch");
+  }) as typeof fetch;
+  let dispose = () => {};
+
+  createRoot((rootDispose) => {
+    dispose = rootDispose;
+    useAppGatewayLifecycle({
+      state,
+      setState,
+      gatewayUrl: () => state().gatewayUrl,
+      gatewayUrlExplicit: false,
+      rootClient: () => ({}) as never,
+      forceNewSession: false,
+      openSession: async () => {},
+    });
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(state().loading).toBe(false);
+  expect(state().bootstrapped).toBe(true);
+  expect(state().connection).toBe("disconnected");
+  expect(state().error).toBeTruthy();
+  dispose();
+});

--- a/apps/gui/tests/unit/runtime-model-sync.test.ts
+++ b/apps/gui/tests/unit/runtime-model-sync.test.ts
@@ -88,6 +88,7 @@ describe("GUI/TUI runtime model config sync", () => {
       default_model_tier: "thinking",
       tura_llm_name: "thinking",
       model_reasoning_effort: "medium",
+      model_acceleration_enabled: false,
     });
     expect(agentRuntimeConfig(undefined, { config })).toEqual({
       defaultModelTier: "thinking",

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 use sysinfo::{Pid, ProcessRefreshKind, System, UpdateKind};
@@ -35,9 +35,11 @@ struct NativeInputFile {
 }
 
 static PENDING_MAIN_WINDOW_ARGS: OnceLock<Mutex<Option<Vec<String>>>> = OnceLock::new();
+static MANAGED_GATEWAY_CHILD: OnceLock<Mutex<Option<Child>>> = OnceLock::new();
+static GATEWAY_START_LOCK: Mutex<()> = Mutex::new(());
 
 fn main() {
-    tauri::Builder::default()
+    let result = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
             remember_gateway_url_from_args(&args);
             restore_main_window_from_args(app, args);
@@ -53,6 +55,10 @@ fn main() {
             remember_active_gateway_url_if_unset();
             queue_main_window_restore(args.clone());
             restore_main_window_from_args(app.handle(), args);
+            std::thread::spawn(|| {
+                let endpoint = default_gateway_endpoint();
+                let _ = start_gateway_with_launcher(&endpoint.url(), false, launch_gateway_process);
+            });
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -61,8 +67,9 @@ fn main() {
             read_input_file,
             read_clipboard_image
         ])
-        .run(tauri::generate_context!())
-        .expect("failed to run tura_gui");
+        .run(tauri::generate_context!());
+    shutdown_managed_gateway_process();
+    result.expect("failed to run tura_gui");
 }
 
 fn restore_main_window_from_args(app: &tauri::AppHandle, args: Vec<String>) {
@@ -231,6 +238,9 @@ fn start_gateway_with_launcher(
     gateway_url_explicit: bool,
     launcher: impl Fn(&GatewayEndpoint, &Path, &Path) -> Result<GatewayEndpoint, String>,
 ) -> Result<StartGatewayResponse, String> {
+    let _start_guard = GATEWAY_START_LOCK
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
     let my_root = current_project_root();
     let instance_home = instance_home_for_runtime_root(&my_root);
     let endpoint =
@@ -351,7 +361,7 @@ fn launch_gateway_process(
     configure_gateway_runtime_command(&mut command, my_root, instance_home, target)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .stdin(Stdio::null());
+        .stdin(Stdio::piped());
     tura_path::process_hardening::hide_child_console_window(&mut command);
     let mut child = command
         .spawn()
@@ -371,6 +381,9 @@ fn launch_gateway_process(
             .map(|url| GatewayEndpoint::parse(&url))
             .unwrap_or_else(|| target.clone());
         if endpoint_is_usable(&candidate, false, my_root, instance_home) {
+            *managed_gateway_child()
+                .lock()
+                .unwrap_or_else(|error| error.into_inner()) = Some(child);
             return Ok(candidate);
         }
         std::thread::sleep(Duration::from_millis(500));
@@ -380,6 +393,33 @@ fn launch_gateway_process(
         "gateway did not become healthy after startup at {}",
         target.url()
     ))
+}
+
+fn managed_gateway_child() -> &'static Mutex<Option<Child>> {
+    MANAGED_GATEWAY_CHILD.get_or_init(|| Mutex::new(None))
+}
+
+fn shutdown_managed_gateway_process() {
+    let _start_guard = GATEWAY_START_LOCK
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let child = managed_gateway_child()
+        .lock()
+        .ok()
+        .and_then(|mut child| child.take());
+    let Some(mut child) = child else {
+        return;
+    };
+    drop(child.stdin.take());
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    while std::time::Instant::now() < deadline {
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 fn configure_gateway_runtime_command<'a>(
@@ -392,6 +432,7 @@ fn configure_gateway_runtime_command<'a>(
         .current_dir(runtime_root)
         .env("TURA_HOME", instance_home)
         .env("TURA_PROJECT_ROOT", runtime_root)
+        .env("TURA_GATEWAY_SHUTDOWN_ON_STDIN_EOF", "1")
         .env(tura_path::TURA_GATEWAY_PORT_ENV, target.port.to_string());
     if let Some(provider_config) = provider_config_for_runtime_root(runtime_root) {
         command.env("TURA_PROVIDER_CONFIG", provider_config);
@@ -1238,6 +1279,10 @@ mod tests {
         assert_eq!(command.get_current_dir(), Some(runtime_root.as_path()));
         assert_eq!(envs.get("TURA_HOME"), Some(&home));
         assert_eq!(envs.get("TURA_PROJECT_ROOT"), Some(&runtime_root));
+        assert_eq!(
+            envs.get("TURA_GATEWAY_SHUTDOWN_ON_STDIN_EOF"),
+            Some(&PathBuf::from("1"))
+        );
         assert_eq!(envs.get("TURA_PROVIDER_CONFIG"), Some(&provider_config));
         assert_eq!(envs.get("TURA_ENV_PATH"), Some(&env_path));
 

--- a/apps/tauri/src-tauri/tauri.windows.conf.json
+++ b/apps/tauri/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,23 @@
+{
+  "bundle": {
+    "resources": {
+      "../../../target/release/tura_exec.exe": "tura_exec.exe",
+      "../../../target/release/tura_gateway.exe": "tura_gateway.exe",
+      "../../../target/release/tura_router.exe": "tura_router.exe",
+      "../../../target/release/tura_session_db.exe": "tura_session_db.exe",
+      "../../../target/release/tura_runtime.exe": "tura_runtime.exe",
+      "../../../target/release/tura-command-generate-media.exe": "tura-command-generate-media.exe",
+      "../../../target/release/tura-command-read-media.exe": "tura-command-read-media.exe",
+      "../../../target/release/tura-command-web-discover.exe": "tura-command-web-discover.exe",
+      "../../../target/release/config/": "config/",
+      "../../../target/release/agents/src/": "agents/src/",
+      "../../../target/release/personas/src/": "personas/src/",
+      "../../../target/release/crates/runtime/src/runtime_prompt/": "crates/runtime/src/runtime_prompt/",
+      "../../../target/release/crates/tools/src/commands/": "crates/tools/src/commands/",
+      "../../../target/release/crates/tools/src/command_run/schema.json": "crates/tools/src/command_run/schema.json",
+      "../../../target/release/commands/generate_media/": "commands/generate_media/",
+      "../../../target/release/commands/read_media/": "commands/read_media/",
+      "../../../target/release/commands/web_discover/": "commands/web_discover/"
+    }
+  }
+}

--- a/apps/tui/src/agent-runtime-config.ts
+++ b/apps/tui/src/agent-runtime-config.ts
@@ -111,11 +111,10 @@ export function applyAgentRuntimeConfig<T extends { provider?: unknown }>(
   provider.default_model_tier = settings.defaultModelTier;
   provider.tura_llm_name = settings.defaultModelTier;
   provider.model_reasoning_effort = normalizeAgentReasoningLevel(settings.reasoningLevel);
+  provider.model_acceleration_enabled = settings.priorityEnabled;
   if (settings.priorityEnabled) {
-    provider.model_acceleration_enabled = true;
     provider.service_tier = "priority";
   } else {
-    delete provider.model_acceleration_enabled;
     delete provider.service_tier;
   }
   return { ...config, provider };

--- a/apps/tui/tests/unit/commands/agent.test.ts
+++ b/apps/tui/tests/unit/commands/agent.test.ts
@@ -130,6 +130,7 @@ test("shared agent runtime config round-trips the same GUI and TUI provider shap
     default_model_tier: "thinking",
     tura_llm_name: "thinking",
     model_reasoning_effort: "medium",
+    model_acceleration_enabled: false,
   });
   assert.deepEqual(agentRuntimeConfig(undefined, { config }), {
     defaultModelTier: "thinking",

--- a/crates/gateway/src/api/global.rs
+++ b/crates/gateway/src/api/global.rs
@@ -5,6 +5,7 @@ use crate::mock::global_store;
 use crate::session::session_store;
 use axum::{
     extract::Path as AxumPath,
+    http::StatusCode,
     response::sse::{Event as SseEvent, KeepAlive, Sse},
     Json,
 };
@@ -104,11 +105,55 @@ pub fn strip_verbatim_prefix(path: &str) -> String {
 // ============================================================================
 
 pub async fn get_config() -> Json<Config> {
+    load_persisted_gui_config();
     Json(global_store().get_config())
 }
 
-pub async fn patch_config(Json(payload): Json<ConfigPatch>) -> Json<Config> {
-    Json(global_store().update_config(payload))
+pub async fn patch_config(
+    Json(payload): Json<ConfigPatch>,
+) -> Result<Json<Config>, (StatusCode, Json<BadRequestError>)> {
+    load_persisted_gui_config();
+    let config = global_store().update_config(payload);
+    write_gui_config(&gui_config_path(), &config).map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(BadRequestError { error }),
+        )
+    })?;
+    Ok(Json(config))
+}
+
+fn gui_config_path() -> PathBuf {
+    tura_path::home_runtime_dir().join("gui-config.json")
+}
+
+fn load_persisted_gui_config() {
+    let Ok(config) = read_gui_config(&gui_config_path()) else {
+        return;
+    };
+    *global_store().config.write() = config;
+}
+
+fn read_gui_config(path: &Path) -> Result<Config, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read GUI config {}: {error}", path.display()))?;
+    serde_json::from_str(&content)
+        .map_err(|error| format!("failed to parse GUI config {}: {error}", path.display()))
+}
+
+fn write_gui_config(path: &Path, config: &Config) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "failed to create GUI config directory {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let content = serde_json::to_string_pretty(config)
+        .map_err(|error| format!("failed to serialize GUI config: {error}"))?;
+    std::fs::write(path, format!("{content}\n"))
+        .map_err(|error| format!("failed to write GUI config {}: {error}", path.display()))
 }
 
 pub async fn get_tura_config() -> Json<TuraConfigResponse> {
@@ -523,12 +568,32 @@ pub async fn upgrade(Json(_payload): Json<UpgradeRequest>) -> Json<UpgradeRespon
 #[cfg(test)]
 mod tests {
     use super::{
-        event_matches_session_filter, event_visible_to_frontend, read_json_config,
-        tura_config_tiers, update_tura_config_tier, TuraConfigUpdate,
+        event_matches_session_filter, event_visible_to_frontend, read_gui_config, read_json_config,
+        tura_config_tiers, update_tura_config_tier, write_gui_config, TuraConfigUpdate,
     };
     use crate::contracts::{
-        GlobalEvent, Message, MessageRole, MessageUpdatedProperties, SessionStatusProperties,
+        Config, GlobalEvent, Message, MessageRole, MessageUpdatedProperties,
+        SessionStatusProperties,
     };
+
+    #[test]
+    fn gui_config_round_trip_preserves_visual_settings() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("nested").join("gui-config.json");
+        let config = Config {
+            theme: Some("dark".to_string()),
+            corner_radius: Some("sharp".to_string()),
+            main_font_size: Some(15),
+            ..Config::default()
+        };
+
+        write_gui_config(&path, &config).expect("write GUI config");
+        let loaded = read_gui_config(&path).expect("read GUI config");
+
+        assert_eq!(loaded.theme.as_deref(), Some("dark"));
+        assert_eq!(loaded.corner_radius.as_deref(), Some("sharp"));
+        assert_eq!(loaded.main_font_size, Some(15));
+    }
 
     #[test]
     fn read_json_config_reports_missing_path_context() {

--- a/crates/gateway/src/api/provider.rs
+++ b/crates/gateway/src/api/provider.rs
@@ -99,6 +99,69 @@ pub fn provider_auth_status_value(provider_id: &str) -> ProviderAuthStatusRespon
     build_provider_auth_status(provider_id)
 }
 
+pub async fn provider_usage(
+    Path(provider_id): Path<String>,
+) -> Json<Option<ProviderUsageResponse>> {
+    let _ = refresh_provider_auth_if_needed(&provider_id, false).await;
+    Json(fetch_provider_usage(&provider_id).await)
+}
+
+async fn fetch_provider_usage(provider_id: &str) -> Option<ProviderUsageResponse> {
+    if provider_id != "codex" {
+        return None;
+    }
+    let status = build_provider_auth_status(provider_id);
+    if status.login.as_deref() != Some("oauth") {
+        return None;
+    }
+    let token = status.token_env.as_deref().and_then(config_value)?;
+    let mut request = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .ok()?
+        .get("https://chatgpt.com/backend-api/wham/usage")
+        .bearer_auth(token);
+    if let Some(account_id) = status.account_id {
+        request = request.header("ChatGPT-Account-Id", account_id);
+    }
+    let response = request.send().await.ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    provider_usage_from_value(&response.json().await.ok()?)
+}
+
+fn provider_usage_from_value(value: &serde_json::Value) -> Option<ProviderUsageResponse> {
+    fn window(value: Option<&serde_json::Value>) -> Option<ProviderUsageWindow> {
+        let value = value?;
+        let window_seconds = value
+            .get("limit_window_seconds")
+            .or_else(|| value.get("window_seconds"))
+            .and_then(serde_json::Value::as_i64)
+            .or_else(|| {
+                value
+                    .get("limit_window_minutes")
+                    .or_else(|| value.get("window_minutes"))
+                    .and_then(serde_json::Value::as_i64)
+                    .and_then(|minutes| minutes.checked_mul(60))
+            });
+        Some(ProviderUsageWindow {
+            used_percent: value.get("used_percent")?.as_f64()?.clamp(0.0, 100.0),
+            resets_at: value.get("reset_at").and_then(serde_json::Value::as_i64),
+            window_seconds,
+        })
+    }
+
+    let mut windows = value
+        .get("rate_limit")?
+        .as_object()?
+        .values()
+        .filter_map(|value| window(Some(value)))
+        .collect::<Vec<_>>();
+    windows.sort_by_key(|window| window.window_seconds.unwrap_or(i64::MAX));
+    (!windows.is_empty()).then_some(ProviderUsageResponse { windows })
+}
+
 pub async fn provider_auth_validate(
     Path(provider_id): Path<String>,
     Json(payload): Json<ProviderAuthValidationRequest>,

--- a/crates/gateway/src/api/provider/config.rs
+++ b/crates/gateway/src/api/provider/config.rs
@@ -1,16 +1,110 @@
 use std::fs;
 use std::io;
 use std::path::{Path as FsPath, PathBuf};
+use std::sync::OnceLock;
+
+static RELEASE_PROVIDER_CONFIG: OnceLock<PathBuf> = OnceLock::new();
 
 pub(crate) fn provider_config_path() -> PathBuf {
-    std::env::var("TURA_PROVIDER_CONFIG")
+    let source = std::env::var("TURA_PROVIDER_CONFIG")
         .ok()
         .filter(|value| !value.trim().is_empty())
         .map(PathBuf::from)
         .or_else(|| runtime_root().and_then(provider_config_in_root))
         .unwrap_or_else(|| {
             source_provider_config_in_root(&std::env::current_dir().unwrap_or_default())
+        });
+    if tura_path::build_kind() != "release" {
+        return source;
+    }
+    RELEASE_PROVIDER_CONFIG
+        .get_or_init(|| {
+            let persistent = tura_path::home_runtime_dir().join("provider_config.json");
+            if materialize_provider_config(&source, &persistent).is_ok() || persistent.is_file() {
+                persistent
+            } else {
+                source
+            }
         })
+        .clone()
+}
+
+fn materialize_provider_config(source: &FsPath, target: &FsPath) -> Result<(), String> {
+    if source == target {
+        return Ok(());
+    }
+    let content = fs::read_to_string(source).map_err(|error| {
+        format!(
+            "failed to read bundled provider config {}: {error}",
+            source.display()
+        )
+    })?;
+    let mut latest: serde_json::Value = serde_json::from_str(&content).map_err(|error| {
+        format!(
+            "failed to parse bundled provider config {}: {error}",
+            source.display()
+        )
+    })?;
+    if let Ok(content) = fs::read_to_string(target) {
+        if let Ok(previous) = serde_json::from_str::<serde_json::Value>(&content) {
+            merge_user_provider_settings(&mut latest, &previous);
+        }
+    }
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "failed to create provider config directory {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let content = serde_json::to_string_pretty(&latest)
+        .map_err(|error| format!("failed to serialize provider config: {error}"))?;
+    fs::write(target, format!("{content}\n")).map_err(|error| {
+        format!(
+            "failed to write persistent provider config {}: {error}",
+            target.display()
+        )
+    })
+}
+
+fn merge_user_provider_settings(latest: &mut serde_json::Value, previous: &serde_json::Value) {
+    if let Some(auth) = previous.get("provider_auth") {
+        latest["provider_auth"] = auth.clone();
+    }
+    let Some(previous_routes) = previous
+        .get("routes")
+        .and_then(serde_json::Value::as_object)
+    else {
+        return;
+    };
+    let Some(latest_routes) = latest
+        .get_mut("routes")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+    for (tier, previous_route) in previous_routes {
+        let Some(previous_provider) = previous_route
+            .get("providers")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|providers| providers.first())
+        else {
+            continue;
+        };
+        let Some(latest_providers) = latest_routes
+            .get_mut(tier)
+            .and_then(|route| route.get_mut("providers"))
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            continue;
+        };
+        if let Some(first) = latest_providers.first_mut() {
+            *first = previous_provider.clone();
+        } else {
+            latest_providers.push(previous_provider.clone());
+        }
+    }
 }
 
 fn runtime_root() -> Option<PathBuf> {
@@ -99,13 +193,47 @@ fn quote_env_value(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::provider_config_path;
+    use super::{materialize_provider_config, provider_config_path};
     use std::ffi::OsString;
     use std::path::PathBuf;
     use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn materialized_provider_config_keeps_user_choices_on_new_bundle() {
+        let root = temp_root("persistent-provider-config");
+        let source = root.join("source.json");
+        let target = root.join("state").join("provider_config.json");
+        std::fs::create_dir_all(&root).expect("config root");
+        std::fs::write(
+            &source,
+            r#"{"provider_auth":{"codex":{"method":"oauth"}},"model_catalog":{"revision":2},"routes":{"thinking":{"providers":[{"provider":"codex","model":"new-default"},{"provider":"fallback","model":"new"}]}}}"#,
+        )
+        .expect("source config");
+        std::fs::create_dir_all(target.parent().expect("target parent")).expect("state dir");
+        std::fs::write(
+            &target,
+            r#"{"provider_auth":{"codex":{"method":"api_key"}},"model_catalog":{"revision":1},"routes":{"thinking":{"providers":[{"provider":"openrouter","model":"chosen"}]}}}"#,
+        )
+        .expect("previous config");
+
+        materialize_provider_config(&source, &target).expect("materialize config");
+        let merged: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).expect("read merged config"))
+                .expect("parse merged config");
+
+        assert_eq!(merged["model_catalog"]["revision"], 2);
+        assert_eq!(merged["provider_auth"]["codex"]["method"], "api_key");
+        assert_eq!(
+            merged["routes"]["thinking"]["providers"][0]["model"],
+            "chosen"
+        );
+        assert_eq!(merged["routes"]["thinking"]["providers"][1]["model"], "new");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
 
     #[test]
     fn provider_config_path_uses_release_project_root_config() {

--- a/crates/gateway/src/api/provider/tests.rs
+++ b/crates/gateway/src/api/provider/tests.rs
@@ -15,6 +15,33 @@ use tokio::sync::Mutex;
 static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
 #[test]
+fn codex_usage_payload_uses_returned_window_durations() {
+    let usage = provider_usage_from_value(&serde_json::json!({
+        "rate_limit": {
+            "allowed": true,
+            "primary_window": {
+                "used_percent": 14,
+                "limit_window_seconds": 604800,
+                "reset_at": 200
+            },
+            "secondary_window": null,
+            "future_window_name": {
+                "used_percent": 25,
+                "window_minutes": 90,
+                "reset_at": 100
+            }
+        }
+    }))
+    .expect("usage windows");
+
+    assert_eq!(usage.windows.len(), 2);
+    assert_eq!(usage.windows[0].window_seconds, Some(5_400));
+    assert_eq!(usage.windows[0].used_percent, 25.0);
+    assert_eq!(usage.windows[1].window_seconds, Some(604_800));
+    assert_eq!(usage.windows[1].used_percent, 14.0);
+}
+
+#[test]
 fn catalog_default_model_has_picker_safe_capabilities_and_limits() {
     let model = default_model_for_provider("openai");
 

--- a/crates/gateway/src/contracts/provider.rs
+++ b/crates/gateway/src/contracts/provider.rs
@@ -107,6 +107,18 @@ pub struct ProviderAuthStatusResponse {
     pub last_error_category: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ProviderUsageWindow {
+    pub used_percent: f64,
+    pub resets_at: Option<i64>,
+    pub window_seconds: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ProviderUsageResponse {
+    pub windows: Vec<ProviderUsageWindow>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ProviderAuthActionResponse {
     pub ok: bool,

--- a/crates/gateway/src/web/server.rs
+++ b/crates/gateway/src/web/server.rs
@@ -144,6 +144,10 @@ pub fn build_router() -> Router {
             get(api::provider::provider_auth_status),
         )
         .route(
+            "/provider/{providerID}/usage",
+            get(api::provider::provider_usage),
+        )
+        .route(
             "/provider/{providerID}/auth/validate",
             post(api::provider::provider_auth_validate),
         )


### PR DESCRIPTION
## Summary

- make the Windows GUI package all required runtime executables and start its gateway automatically
- make the GUI own the gateway process so the gateway, router, runtime, and session DB shut down when the window closes
- persist GUI, provider, and dynamically created agent settings under the writable Tura home so upgrades do not overwrite them
- write acceleration `false` explicitly so turning acceleration off works on the first save
- add context-window fill and Codex usage meters to the conversation header
- discover usage windows dynamically from the returned duration instead of assuming fixed 5-hour and weekly limits
- refresh provider limits and the selected session's context metrics every 15 seconds while retaining live event updates
- leave the loading state and show the connection error when gateway startup fails

## Root causes

The Windows bundle did not include the complete runtime resource mapping and the GUI did not retain ownership of the gateway child process. Release settings were also read or written relative to bundled/install-time files, which are replaced during upgrades. Acceleration-off removed the setting instead of persisting `false`, and usage UI semantics were tied to two assumed window names even when the provider returned only a weekly window.

## User impact

The installed Windows GUI now starts without a separately launched gateway, exits without leaving `tura_session_db` or other backend processes running, and preserves user settings across reinstall/update. Usage indicators reflect whatever rate-limit windows OpenAI currently returns (for example, a single one-week window), refresh every 15 seconds, and context usage is visible per session.

## Validation

- `cargo test -p gateway codex_usage_payload_uses_returned_window_durations`
- `bun run check` in `apps/gui` (lint, format, typecheck, unused checks, production build)
- `bun run test:unit` in `apps/gui` (208 passed)
- `scripts/build-release.ps1` produced MSI and NSIS bundles before the polling-only follow-up
- installed NSIS smoke test confirmed gateway autostart, one live 604800-second usage window, and zero remaining Tura processes after normal GUI close before the polling-only follow-up
- the 15-second polling follow-up was validated without launching or contacting a live Tura instance
