### PR TITLE
Fix large session DB responses

### DIFF
--- a/crates/session_log/src/ipc.rs
+++ b/crates/session_log/src/ipc.rs
@@ -399,6 +399,10 @@ fn publish_addr(addr: &SocketAddr) -> Result<()> {
 }
 
 fn handle_connection(store: SessionLogStore, stream: TcpStream) -> Result<()> {
+    // BSD/macOS accepted sockets inherit O_NONBLOCK from the listener. Restore
+    // blocking I/O so large NDJSON requests and responses are not truncated at
+    // the socket-buffer boundary when read_line/write_all returns WouldBlock.
+    stream.set_nonblocking(false)?;
     stream.set_read_timeout(Some(READ_TIMEOUT))?;
     let mut writer = stream.try_clone()?;
     let reader = BufReader::new(stream);
@@ -493,6 +497,62 @@ mod tests {
             version: String::new(),
         };
         assert!(ensure_version_compatible(&unversioned).is_ok());
+    }
+
+    #[test]
+    fn nonblocking_listener_serves_responses_larger_than_the_socket_buffer() {
+        let root = tempfile::tempdir().expect("temp db root");
+        let store = SessionLogStore::open(root.path()).expect("open session store");
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind loopback listener");
+        listener
+            .set_nonblocking(true)
+            .expect("set listener nonblocking");
+        let addr = listener.local_addr().expect("listener address");
+        let mut client = TcpStream::connect(addr).expect("connect client");
+        client
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .expect("set client read timeout");
+        client
+            .set_write_timeout(Some(Duration::from_secs(10)))
+            .expect("set client write timeout");
+
+        let (server_stream, _) = listener.accept().expect("accept queued client");
+        let server = std::thread::spawn(move || handle_connection(store, server_stream));
+
+        let oversized_variant = "x".repeat(1_000_000);
+        let request = serde_json::json!({ "command": oversized_variant }).to_string();
+        client
+            .write_all(request.as_bytes())
+            .expect("write oversized request");
+        client.write_all(b"\n").expect("terminate request");
+        client.flush().expect("flush request");
+
+        let mut response_line = String::new();
+        BufReader::new(client.try_clone().expect("clone client"))
+            .read_line(&mut response_line)
+            .expect("read oversized response");
+        assert!(
+            response_line.ends_with('\n'),
+            "oversized response must end with the NDJSON delimiter"
+        );
+        assert!(
+            response_line.len() > 1_000_000,
+            "test response must exceed the platform socket buffer"
+        );
+        assert!(
+            matches!(
+                serde_json::from_str::<SessionLogResponse>(response_line.trim())
+                    .expect("decode complete oversized response"),
+                SessionLogResponse::Error { .. }
+            ),
+            "invalid oversized request should receive a structured error"
+        );
+
+        drop(client);
+        server
+            .join()
+            .expect("session_db connection thread")
+            .expect("serve oversized response");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- restore blocking mode on each accepted `session_db` connection
- add a regression test that round-trips an NDJSON response larger than 1 MB

## Why

The session DB listener is nonblocking so its accept loop can poll for shutdown. On BSD/macOS, accepted sockets inherit `O_NONBLOCK` from that listener. Large persisted-session responses could then fill the socket buffer, cause `write_all` to return `WouldBlock`, and close the connection after emitting only a partial JSON document. Follow-up prompts then failed while decoding the truncated response. See issue #5 (MANO failed while processing this prompt: failed to enqueue turn prompt)

Restoring blocking mode matches the existing synchronous, one-thread-per-connection design. It is safe on platforms where accepted sockets are already blocking, and it also makes the intended connection semantics explicit on platforms that inherit the listener state.

## Impact

- fixes follow-up prompts for sessions whose persisted snapshots exceed the socket buffer on macOS/BSD
- no database migration or stored-session rewrite is required
- no expected behavioral change for platforms whose accepted sockets already use blocking I/O

## Validation

- `cargo test -p session_log --lib` (41 passed)
- `TURA_BUILD_KIND=release cargo build --release -p session_log --bin tura_session_db`
- manually confirmed that a previously failing follow-up prompt succeeds with the rebuilt service
