### PR TITLE
fix(tui): streamline autocomplete selection flow

### DIFF
--- a/apps/tui/src/locales/en.json
+++ b/apps/tui/src/locales/en.json
@@ -251,6 +251,7 @@
   "aboutStarOpened": "GitHub opened; add the star there",
   "aboutLinkOpened": "opened {target}",
   "settingAgentHint": "Up/Down select, Enter apply; Esc returns to settings top. The agent controls the default task style, tool policy, and working behavior.",
+  "settingApplied": "{setting} set to {value}",
   "settingDetailHint": "Up/Down select, Enter apply; Esc returns to settings top.",
   "settingDetailPage": "{name} setting page",
   "settingInputComposerHint": "Enter save, Esc cancel",

--- a/apps/tui/src/locales/zh-CN.json
+++ b/apps/tui/src/locales/zh-CN.json
@@ -251,6 +251,7 @@
   "aboutStarOpened": "已打开 GitHub，请在页面中添加 Star",
   "aboutLinkOpened": "已打开{target}",
   "settingAgentHint": "上下选择，Enter 应用；Esc 返回设置顶部。智能体决定默认任务风格、工具策略和工作方式。",
+  "settingApplied": "{setting}已设置为{value}",
   "settingDetailHint": "上下选择，Enter 应用；Esc 返回设置顶部。",
   "settingDetailPage": "{name}设置页面",
   "settingInputComposerHint": "Enter 保存，Esc 取消",

--- a/apps/tui/src/tui/app.ts
+++ b/apps/tui/src/tui/app.ts
@@ -60,7 +60,6 @@ import {
 } from "./composer-editor.js";
 import {
   completedSlashCommand,
-  slashCommandQuery,
   slashCommandSuggestions,
   type SlashCommandDefinition,
 } from "./slash-commands.js";
@@ -610,13 +609,10 @@ export async function handleTuiKeypress(
         return;
       }
       const suggestions = activeSlashCommandSuggestions(state);
-      const query = slashCommandQuery(state.composer);
       const selectedSuggestion = selectedSlashCommand(state, suggestions);
-      if (selectedSuggestion && query !== selectedSuggestion.name) {
-        applySlashCommandCompletion(state, dispatch, suggestions);
-        return;
-      }
-      const value = state.composer.trim();
+      const value = selectedSuggestion
+        ? completedSlashCommand(selectedSuggestion).trim()
+        : state.composer.trim();
       dispatch({ type: "composer", value: "" });
       if (!value) return;
       if (value.startsWith("/")) {

--- a/apps/tui/src/tui/settings-actions.ts
+++ b/apps/tui/src/tui/settings-actions.ts
@@ -32,15 +32,13 @@ export async function applySelectedSetting(
   if (detail === "model") {
     if (typeof value !== "string") return;
     const config = await client.patchSessionConfig(settingPatch(detail, value) ?? { model: value });
-    dispatch({ type: "session-config", value: config });
-    dispatch({ type: "notice", value: undefined });
+    completeSettingSelection(dispatch, config, detail, selected[0]);
     return;
   }
   if (detail === "agent") {
     if (typeof value !== "string") return;
     const config = await client.patchSessionConfig({ active_agent: value });
-    dispatch({ type: "session-config", value: config });
-    dispatch({ type: "notice", value: undefined });
+    completeSettingSelection(dispatch, config, detail, selected[0]);
     return;
   }
   if (detail === "provider" && typeof value === "string") {
@@ -59,8 +57,40 @@ export async function applySelectedSetting(
   if (detail === "language" && typeof value === "string") {
     setLanguage(parseLanguage(value));
   }
+  completeSettingSelection(dispatch, config, detail, selected[0]);
+}
+
+function completeSettingSelection(
+  dispatch: TuiDispatch,
+  config: AppState["sessionConfig"],
+  detail: Exclude<AppState["settingDetail"], undefined>,
+  value: string,
+): void {
+  if (!config) return;
   dispatch({ type: "session-config", value: config });
-  dispatch({ type: "notice", value: undefined });
+  dispatch({ type: "close-panels" });
+  dispatch({
+    type: "notice",
+    value: t("settingApplied", { setting: settingLabel(detail), value }),
+  });
+}
+
+function settingLabel(detail: Exclude<AppState["settingDetail"], undefined>): string {
+  const labels: Record<Exclude<AppState["settingDetail"], undefined>, string> = {
+    model: t("settingModel"),
+    provider: t("settingProvider"),
+    providerAuth: t("settingProvider"),
+    agent: t("settingAgent"),
+    persona: t("settingPersona"),
+    language: t("settingLanguage"),
+    session: t("settingSession"),
+    variant: t("settingReasoning"),
+    priority: t("settingPriority"),
+    validator: t("settingValidator"),
+    stallGuard: t("settingStallGuard"),
+    about: t("settingAbout"),
+  };
+  return labels[detail];
 }
 
 export async function applyAboutAction(

--- a/apps/tui/tests/unit/tui/app-keyboard-navigation.test.ts
+++ b/apps/tui/tests/unit/tui/app-keyboard-navigation.test.ts
@@ -37,11 +37,28 @@ test("Tab completes the selected slash command and arrows navigate suggestions",
   assert.equal(harness.getState().composerCursor, "/models ".length);
 });
 
-test("Enter accepts a partial command before executing it", async () => {
+test("Enter executes the selected partial command without an extra keypress", async () => {
   const harness = stateHarness();
   await press(harness, "/set", { sequence: "/set" });
-  await press(harness, "", { name: "return" });
-  assert.equal(harness.getState().composer, "/settings ");
+  await handleTuiKeypress(
+    {
+      getSessionConfig: async () => ({
+        active_provider: "mock",
+        active_agent: "balanced",
+        active_model: "mock-fast",
+        model: "mock/mock-fast",
+        model_variant: "high",
+        model_acceleration_enabled: false,
+      }),
+    } as never,
+    harness.getState,
+    harness.dispatch,
+    "",
+    { name: "return" },
+  );
+
+  assert.equal(harness.getState().composer, "");
+  assert.equal(harness.getState().settingsOpen, true);
 });
 
 test("slash commands remain available while a non-settings panel is open", async () => {

--- a/apps/tui/tests/unit/tui/settings-actions-auth.test.ts
+++ b/apps/tui/tests/unit/tui/settings-actions-auth.test.ts
@@ -8,6 +8,43 @@ import { settingsLines } from "../../../src/tui/render/settings.js";
 import { setActiveCapabilities, stripAnsi } from "../../../src/tui/render-terminal.js";
 import { plainCapabilities, richCapabilities } from "../../../src/tui/capabilities.js";
 
+test("applying a leaf setting returns to chat and shows the selected value", async () => {
+  let state: AppState = {
+    ...initialState("C:/repo"),
+    settingsOpen: true,
+    settingDetail: "persona",
+    sessionConfig: {
+      active_provider: "mock",
+      active_agent: "balanced",
+      active_persona: "tura",
+      active_model: "mock-fast",
+      model: "mock/mock-fast",
+      model_variant: "high",
+      model_acceleration_enabled: false,
+    },
+    personas: [
+      { summary: { id: "tura", source: "static" } },
+      { summary: { id: "wonderful", source: "static" } },
+    ],
+    selectedSettingOptionIndex: 1,
+  };
+
+  await applySelectedSetting(
+    mockClient({
+      patchSessionConfig: async (patch) => ({ ...state.sessionConfig, ...patch }),
+    }),
+    () => state,
+    (action) => {
+      state = reducer(state, action);
+    },
+  );
+
+  assert.equal(state.settingsOpen, false);
+  assert.equal(state.settingDetail, undefined);
+  assert.equal(state.sessionConfig?.active_persona, "wonderful");
+  assert.equal(state.notice, "Persona set to wonderful");
+});
+
 test("provider OAuth setting opens the browser and starts callback input", async () => {
   let state = providerAuthState();
   const opened: string[] = [];


### PR DESCRIPTION
## Pull request type

Choose one primary type. If the change needs more focused questions, use the matching template in
[PULL_REQUEST_TEMPLATE/](https://github.com/Tura-AI/tura/tree/main/.github/PULL_REQUEST_TEMPLATE):

- [x] [Bug fix](https://github.com/Tura-AI/tura/compare?expand=1&template=bug_fix.md)
- [ ] [Feature or behavior change](https://github.com/Tura-AI/tura/compare?expand=1&template=feature.md)
- [ ] [Performance or efficiency claim](https://github.com/Tura-AI/tura/compare?expand=1&template=performance.md)
- [ ] [Provider compatibility](https://github.com/Tura-AI/tura/compare?expand=1&template=provider.md)
- [ ] [Documentation only](https://github.com/Tura-AI/tura/compare?expand=1&template=documentation.md)
- [ ] Maintenance or other

## Outcome

TUI autocomplete selections now execute with a single Enter press. For example, typing `/set`, selecting `/settings`, and pressing Enter opens the settings menu immediately instead of only completing the command and requiring a second Enter.

After a user confirms a terminal settings choice such as a persona, model, agent, language, reasoning level, or priority mode, the TUI now returns to the chat surface and displays localized confirmation such as `Persona set to wonderful`.

No linked issue.

The change is limited to the existing TUI Enter handler and settings-selection action flow. Intermediate branches such as provider authentication remain open because they require additional interaction.

## Scope and compatibility

- Changed contracts, state, storage, protocol, CLI, GUI, TUI, or installation behavior: TUI keyboard and settings-navigation behavior only. English and Simplified Chinese confirmation text was added.
- Compatibility or migration risk: Low. No contracts, protocols, configuration formats, or persistent storage changed. Enter now executes the highlighted slash-command suggestion; Tab continues to complete the suggestion without executing it.
- Explicitly out of scope: Provider-authentication subflows, About actions, GUI behavior, non-interactive CLI behavior, gateway protocols, and storage migrations.

## Verification

```text
cd apps/tui && npm run check -> passed lint, formatting, typecheck, unused-code analysis, and build
cd apps/tui && npm run test:unit -> 284 tests passed, 0 failed
git diff --check -> passed with no whitespace errors
TURA_BUILD_KIND=release bun build --compile --outfile target/release/tura.next apps/tui/src/index.ts -> release TUI compiled successfully
target/release/tura.next --help -> executable smoke test passed
```

Affected matrix:

- Linux TUI keyboard and settings-selection behavior: verified through unit tests and a compiled release executable.
- macOS and Windows TUI: not run locally; the affected keypress and reducer/action paths are platform-independent and covered at the owning TypeScript unit-test layer.
- Session configuration updates: fixture-covered through a mocked gateway client.
- Provider/protocol behavior: not applicable; no provider or protocol code changed.
- Persistent state: not applicable; no schema or storage behavior changed.

## Type-specific evidence

- Bug reproduction:
  - Type `/set` and press Enter while `/settings` is highlighted.
  - Before this fix, the composer changed to `/settings ` and another Enter was required.
  - Navigate through Settings → Persona, select a persona, and press Enter.
  - Before this fix, the selection gained its active marker but the settings detail remained open and no confirmation was shown.
- Root cause:
  - The Enter handler returned immediately after applying the highlighted slash-command completion instead of executing the selected command.
  - Successful leaf-setting updates dispatched the new session configuration but preserved `settingsOpen` and cleared the notice.
- Smallest owning regression layer:
  - TUI keyboard-navigation unit test for single-Enter execution of partial slash commands.
  - Settings-action/reducer unit test for closing leaf settings and displaying the selected value.
- Result after the fix:
  - Enter executes the highlighted slash command immediately.
  - Successful leaf selections close the settings panels, return to chat, and show localized confirmation.
  - Intermediate settings branches continue to behave as before.

## Safety and responsibility

- [x] No credentials, private session data, unsafe provider logs, or generated local state are included.
- [x] Public evidence was sanitized according to the
      [contribution guide](https://github.com/Tura-AI/tura/blob/main/docs/contributing-guide.md#safe-and-reproducible-evidence).
- [x] A human is the primary submitter and accepts responsibility for correctness, licensing, provenance, verification, and the statements in this pull request.
- [x] I have the right to submit all included code, data, prompts, fixtures, and generated material under the repository license.

Meaningful tool or AI assistance, if useful to reviewers (optional): OpenAI Codex assisted with implementation, regression tests, code review, and local validation.
