### PR TITLE
Staging, Fix TUI final response scrollback handoff and cargo update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [workspace]
-resolver = "2"
+resolver = "3"
 default-members = [
   ".",
   "commands/generate_media",
@@ -50,7 +50,7 @@ members = [
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Tura"]
 license = "AGPL-3.0-or-later"
 

--- a/apps/gui/tests/e2e/business/gui_tui_shared_gateway_stream_e2e.py
+++ b/apps/gui/tests/e2e/business/gui_tui_shared_gateway_stream_e2e.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import queue
+import re
 import socket
 import subprocess
 import threading
@@ -354,6 +355,23 @@ async def tui_buffer(page) -> str:
     )
 
 
+async def tui_viewport(page) -> str:
+    return await page.evaluate(
+        """() => {
+          const terminal = window.__turaTerminal;
+          const buffer = terminal?.buffer.active;
+          if (!terminal || !buffer) return '';
+          const lines = [];
+          const start = buffer.viewportY;
+          const end = Math.min(buffer.length, start + terminal.rows);
+          for (let index = start; index < end; index += 1) {
+            lines.push(buffer.getLine(index)?.translateToString(true) ?? '');
+          }
+          return lines.join('\\n');
+        }"""
+    )
+
+
 async def run_flow(gateway: SharedGateway):
     node = "node.exe" if os.name == "nt" else "node"
     gui_process = None
@@ -421,6 +439,21 @@ async def run_flow(gateway: SharedGateway):
             )
             await expect(gui_page.locator(".assistant-thinking-text")).to_be_visible(timeout=20_000)
             await tui_page.wait_for_function("() => Boolean(window.__turaTerminal)", timeout=20_000)
+            await tui_page.wait_for_function(
+                r"""() => {
+                  const terminal = window.__turaTerminal;
+                  const buffer = terminal?.buffer.active;
+                  if (!terminal || !buffer) return false;
+                  const lines = [];
+                  const start = buffer.viewportY;
+                  const end = Math.min(buffer.length, start + terminal.rows);
+                  for (let index = start; index < end; index += 1) {
+                    lines.push(buffer.getLine(index)?.translateToString(true) ?? '');
+                  }
+                  return /thinking\s+\d+s?/iu.test(lines.join(' '));
+                }""",
+                timeout=20_000,
+            )
 
             global_path = "/event"
             session_path = f"/session/{SESSION_ID}/events"
@@ -509,6 +542,21 @@ async def run_flow(gateway: SharedGateway):
                 timeout=15_000,
             )
             await expect(gui_page.locator(".assistant-thinking-text")).to_have_count(0)
+            await tui_page.wait_for_function(
+                r"""() => {
+                  const terminal = window.__turaTerminal;
+                  const buffer = terminal?.buffer.active;
+                  if (!terminal || !buffer) return false;
+                  const lines = [];
+                  const start = buffer.viewportY;
+                  const end = Math.min(buffer.length, start + terminal.rows);
+                  for (let index = start; index < end; index += 1) {
+                    lines.push(buffer.getLine(index)?.translateToString(true) ?? '');
+                  }
+                  return !/thinking\s+\d+s?/iu.test(lines.join(' '));
+                }""",
+                timeout=15_000,
+            )
             OUT.mkdir(parents=True, exist_ok=True)
             await gui_page.screenshot(path=str(OUT / "gui-final.png"), full_page=True)
             await tui_page.screenshot(path=str(OUT / "tui-final.png"), full_page=True)
@@ -521,6 +569,9 @@ async def run_flow(gateway: SharedGateway):
                         "sessionConnections": gateway.connection_count(session_path),
                         "gui": final_gui,
                         "tuiHasFinal": FINAL_TEXT in final_tui,
+                        "tuiHasThinking": bool(
+                            re.search(r"thinking\s+\d+s?", await tui_viewport(tui_page), re.I)
+                        ),
                         "browserErrors": browser_errors,
                     },
                     indent=2,

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -74,10 +74,10 @@ fn main() {
 
 fn restore_main_window_from_args(app: &tauri::AppHandle, args: Vec<String>) {
     if let Some(window) = app.get_webview_window("main") {
-        if let Ok(base_url) = window.url() {
-            if let Some(url) = gui_startup_url_from_args(base_url, args) {
-                let _ = window.navigate(url);
-            }
+        if let Ok(base_url) = window.url()
+            && let Some(url) = gui_startup_url_from_args(base_url, args)
+        {
+            let _ = window.navigate(url);
         }
         let _ = window.show();
         let _ = window.unminimize();
@@ -129,11 +129,12 @@ fn queue_main_window_restore(args: Vec<String>) -> bool {
     if GuiStartupParams::parse(args.clone()).is_none() {
         return false;
     }
-    if let Ok(mut pending) = pending_main_window_args().lock() {
-        *pending = Some(args);
-        true
-    } else {
-        false
+    match pending_main_window_args().lock() {
+        Ok(mut pending) => {
+            *pending = Some(args);
+            true
+        }
+        _ => false,
     }
 }
 
@@ -198,10 +199,17 @@ fn remember_active_gateway_url_if_unset() {
 
 fn remember_gateway_url(gateway_url: &str) {
     if let Some(url) = non_empty_gateway_url(gateway_url) {
-        std::env::set_var(
-            tura_path::TURA_GATEWAY_URL_ENV,
-            GatewayEndpoint::parse(&url).url(),
-        );
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(
+                tura_path::TURA_GATEWAY_URL_ENV,
+                GatewayEndpoint::parse(&url).url(),
+            )
+        };
     }
 }
 
@@ -376,9 +384,7 @@ fn usable_gateway_identity(
     my_root: &Path,
     instance_home: &Path,
 ) -> Option<GatewayIdentity> {
-    let Some(identity) = gateway_identity(endpoint) else {
-        return None;
-    };
+    let identity = gateway_identity(endpoint)?;
     (explicit || gateway_identity_matches_instance(&identity, my_root, instance_home))
         .then_some(identity)
 }
@@ -754,10 +760,10 @@ fn resolve_gateway_binary(my_root: &Path) -> Result<PathBuf, String> {
     {
         candidates.push(PathBuf::from(value));
     }
-    if let Ok(current_exe) = std::env::current_exe() {
-        if let Some(dir) = current_exe.parent() {
-            candidates.push(dir.join(exe_name));
-        }
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(dir) = current_exe.parent()
+    {
+        candidates.push(dir.join(exe_name));
     }
     candidates.push(my_root.join("target").join("release").join(exe_name));
     candidates.push(my_root.join("bin").join(exe_name));
@@ -783,11 +789,11 @@ fn select_gateway_endpoint(
     }
     let candidates = gateway_endpoint_candidates(requested_url, instance_home, &default_endpoint);
     for candidate in candidates {
-        if let Some(identity) = gateway_identity(&candidate) {
-            if gateway_identity_matches_instance(&identity, my_root, instance_home) {
-                write_active_gateway_url(instance_home, &candidate)?;
-                return Ok(candidate);
-            }
+        if let Some(identity) = gateway_identity(&candidate)
+            && gateway_identity_matches_instance(&identity, my_root, instance_home)
+        {
+            write_active_gateway_url(instance_home, &candidate)?;
+            return Ok(candidate);
         }
     }
     if let Some(candidate) = same_home_gateway_process_endpoint(instance_home)
@@ -1941,7 +1947,14 @@ mod tests {
                 .map(|(key, _)| (*key, std::env::var_os(key)))
                 .collect::<Vec<_>>();
             for (key, value) in values {
-                std::env::set_var(key, value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(key, value)
+                };
             }
             Self { previous }
         }
@@ -1951,9 +1964,23 @@ mod tests {
         fn drop(&mut self) {
             for (key, value) in self.previous.drain(..).rev() {
                 if let Some(value) = value {
-                    std::env::set_var(key, value);
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    };
                 } else {
-                    std::env::remove_var(key);
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    };
                 }
             }
         }

--- a/apps/tui/ARCHITECTURE.md
+++ b/apps/tui/ARCHITECTURE.md
@@ -662,6 +662,11 @@ Chat rendering owns only the mutable live tail. Once a live row has overflowed
 into terminal scrollback, later stream deltas must preserve that terminal-owned
 prefix and may only append new rows or repaint the reserved tail. Rebuilding the
 scrollback for a live-content reflow destroys a user's middle viewport position.
+While that live tail exists, newly stable messages remain in the same mutable
+tail even if their timestamps place them before the active text stream. This
+keeps delayed or completed command snapshots from being inserted into the
+terminal-owned prefix; the complete tail moves to the cache only after live
+streaming ends.
 The Runtime feed must finalize a live text part with the exact accumulated live
 text, so completion and later session hydration preserve the same paragraphs,
 indentation, and rendered transcript.

--- a/apps/tui/ARCHITECTURE.md
+++ b/apps/tui/ARCHITECTURE.md
@@ -667,6 +667,12 @@ tail even if their timestamps place them before the active text stream. This
 keeps delayed or completed command snapshots from being inserted into the
 terminal-owned prefix; the complete tail moves to the cache only after live
 streaming ends.
+While a session is busy, assistant messages in the current user turn belong to
+that mutable tail even before a live delta or running command identifies them.
+This prevents a stable text snapshot from entering terminal-owned scrollback
+and then being appended again when a later command update makes the same
+message live. Completed command snapshots remain there until the session is
+explicitly idle; command completion alone is not a safe cache boundary.
 The Runtime feed must finalize a live text part with the exact accumulated live
 text, so completion and later session hydration preserve the same paragraphs,
 indentation, and rendered transcript.

--- a/apps/tui/src/tui/render.ts
+++ b/apps/tui/src/tui/render.ts
@@ -187,16 +187,26 @@ export function renderChatFrameParts(
   );
   const baseCache = reusableCache ?? renderChatCache(state, capabilities, renderCols, groups.cache);
   const tailCacheMessages = groups.cache.slice(baseCache.cacheMessageCount);
-  const tailCacheRows = transcriptRenderLinesForMessages(state, renderCols, tailCacheMessages, {
-    commandMode: "cache",
-  });
+  // Do not move the cache/live boundary while terminal scrollback owns a live
+  // prefix. Stable command snapshots join the mutable tail until it finalizes.
+  const mutableTailCacheMessages = groups.live.length ? tailCacheMessages : [];
+  const appendedTailCacheMessages = groups.live.length ? [] : tailCacheMessages;
+  const tailCacheRows = transcriptRenderLinesForMessages(
+    state,
+    renderCols,
+    appendedTailCacheMessages,
+    {
+      commandMode: "cache",
+    },
+  );
   const renderedCache = appendRenderedChatCache(
     baseCache,
     tailCacheRows,
-    tailCacheMessages.length,
+    appendedTailCacheMessages.length,
     renderCols,
   );
-  const activeLiveRows = transcriptRenderLinesForMessages(state, renderCols, groups.live, {
+  const activeLiveMessages = [...mutableTailCacheMessages, ...groups.live];
+  const activeLiveRows = transcriptRenderLinesForMessages(state, renderCols, activeLiveMessages, {
     commandMode: "live",
   });
   const liveRows = liveLinesWithCacheBoundary(renderedCache.cacheRows, activeLiveRows);
@@ -229,8 +239,8 @@ export function renderChatFrameParts(
     cacheLines,
     liveFrame: live.frame,
     liveRows,
-    tailCacheMessageCount: tailCacheMessages.length,
-    activeLiveMessageCount: groups.live.length,
+    tailCacheMessageCount: appendedTailCacheMessages.length,
+    activeLiveMessageCount: activeLiveMessages.length,
     liveStreamKey: activeLiveStreamKey(state),
     chromeFrame: chrome.frame,
     chromeCursor: chrome.cursor,

--- a/apps/tui/src/tui/render/transcript.ts
+++ b/apps/tui/src/tui/render/transcript.ts
@@ -158,6 +158,19 @@ function liveMessageIDs(state: AppState, messages: Message[]): Set<string> {
       .filter((stream) => !sessionID || !stream.sessionID || stream.sessionID === sessionID)
       .map((stream) => stream.messageID),
   );
+  if (isBusyState(state)) {
+    let currentTurnStart: number | undefined;
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      if (messages[index]?.role !== "user") continue;
+      currentTurnStart = index + 1;
+      break;
+    }
+    if (currentTurnStart !== undefined) {
+      for (const message of messages.slice(currentTurnStart)) {
+        if (message.role === "assistant") ids.add(message.id);
+      }
+    }
+  }
   for (const message of messages) {
     if (message.role === "assistant" && messageHasRunningPart(message)) ids.add(message.id);
   }

--- a/apps/tui/tests/e2e/business/tui_mock_gateway_stream_flow.mjs
+++ b/apps/tui/tests/e2e/business/tui_mock_gateway_stream_flow.mjs
@@ -856,7 +856,70 @@ async function main() {
       "handoff command should finalize into cache",
     );
 
-    // Phase 7: Markdown headings must have identical marker-free bold
+    // Phase 7: reproduce a recent command completing while a long final
+    // response has already spilled into scrollback. The whole response must
+    // remain in xterm after the live-to-cache handoff, not only its tail.
+    gatewayEvent("session.status", { sessionID, status: "busy" });
+    const completeResponseMessageID = "msg-complete-final-response";
+    const completeResponsePartID = "part-complete-final-response";
+    const completeResponseLines = Array.from(
+      { length: 36 },
+      (_item, index) => `COMPLETE_FINAL_RESPONSE_LINE_${String(index + 1).padStart(2, "0")}`,
+    );
+    const completeResponseText = completeResponseLines.join("\n");
+    const completeResponseCreatedAt = Date.now();
+    const recentCommand = {
+      id: "msg-command-before-final-response",
+      cmd: "RECENT_COMMAND_BEFORE_FINAL_RESPONSE",
+      at: completeResponseCreatedAt - 1,
+    };
+    upsertCommand(recentCommand, "running");
+    await page.waitForFunction(
+      (marker) => document.body.innerText.includes(marker),
+      recentCommand.cmd,
+      { timeout: 5_000 },
+    );
+    await streamShortChunks(
+      completeResponseText,
+      completeResponseMessageID,
+      completeResponsePartID,
+      "properties",
+    );
+    await page.waitForFunction(
+      (marker) => document.body.innerText.includes(marker),
+      completeResponseLines.at(-1),
+      { timeout: 5_000 },
+    );
+    upsertCommand(recentCommand, "completed");
+    upsertMessage({
+      id: completeResponseMessageID,
+      sessionID,
+      role: "assistant",
+      parts: [
+        {
+          id: completeResponsePartID,
+          type: "text",
+          text: completeResponseText,
+        },
+      ],
+      created_at: completeResponseCreatedAt,
+      updated_at: Date.now(),
+    });
+    session = { ...session, status: "idle", updated_at: Date.now() };
+    gatewayEvent("session.status", { sessionID, status: "idle" });
+    await waitForComposer(page);
+    await delay(250);
+    captures.push(await capture(page, "14-complete-final-response"));
+    const completeResponseBuffer = await terminalBufferText(page);
+    for (const line of completeResponseLines) {
+      assert.equal(
+        markerCount(completeResponseBuffer, line),
+        1,
+        `${line} must remain recoverable exactly once after finalization`,
+      );
+    }
+
+    // Phase 8: Markdown headings must have identical marker-free bold
     // presentation while live and after the durable message replaces the feed.
     gatewayEvent("session.status", { sessionID, status: "busy" });
     const headingMessageID = "msg-heading-handoff";
@@ -894,7 +957,7 @@ async function main() {
     session = { ...session, status: "idle", updated_at: Date.now() };
     gatewayEvent("session.status", { sessionID, status: "idle" });
     await waitForComposer(page);
-    captures.push(await capture(page, "14-heading-handoff-final"));
+    captures.push(await capture(page, "15-heading-handoff-final"));
     const headingBuffer = await terminalBufferText(page);
     assert.equal(await terminalMarkerIsBold(page, "TUI_PRIMARY_HEADING"), true);
     assert.equal(await terminalMarkerIsBold(page, "TUI_SECONDARY_HEADING"), true);

--- a/apps/tui/tests/e2e/business/tui_mock_gateway_stream_flow.mjs
+++ b/apps/tui/tests/e2e/business/tui_mock_gateway_stream_flow.mjs
@@ -919,7 +919,78 @@ async function main() {
       );
     }
 
-    // Phase 8: Markdown headings must have identical marker-free bold
+    // Phase 8: a stable assistant snapshot can arrive before a command update
+    // makes that same message live. It must not first enter terminal-owned
+    // cache and then be appended a second time as a live message.
+    gatewayEvent("session.status", { sessionID, status: "busy" });
+    const commandAfterTextMessageID = "msg-command-after-stable-text";
+    const commandAfterTextPartID = "part-command-after-stable-text";
+    const commandAfterTextLines = Array.from(
+      { length: 36 },
+      (_item, index) => `COMMAND_AFTER_TEXT_LINE_${String(index + 1).padStart(2, "0")}`,
+    );
+    const commandAfterText = commandAfterTextLines.join("\n");
+    const commandAfterTextCreatedAt = Date.now();
+    const delayedCommand = {
+      id: commandAfterTextMessageID,
+      cmd: "COMMAND_AFTER_STABLE_TEXT",
+      at: commandAfterTextCreatedAt,
+    };
+    upsertMessage({
+      id: commandAfterTextMessageID,
+      sessionID,
+      role: "assistant",
+      parts: [{ id: commandAfterTextPartID, type: "text", text: commandAfterText }],
+      created_at: commandAfterTextCreatedAt,
+      updated_at: Date.now(),
+    });
+    await page.waitForFunction(
+      (marker) => document.body.innerText.includes(marker),
+      commandAfterTextLines.at(-1),
+      { timeout: 5_000 },
+    );
+    upsertMessage({
+      id: commandAfterTextMessageID,
+      sessionID,
+      role: "assistant",
+      parts: [
+        { id: commandAfterTextPartID, type: "text", text: commandAfterText },
+        commandPart(delayedCommand, "running"),
+      ],
+      created_at: commandAfterTextCreatedAt,
+      updated_at: Date.now(),
+    });
+    await page.waitForFunction(
+      (marker) => document.body.innerText.includes(marker),
+      delayedCommand.cmd,
+      { timeout: 5_000 },
+    );
+    upsertMessage({
+      id: commandAfterTextMessageID,
+      sessionID,
+      role: "assistant",
+      parts: [
+        { id: commandAfterTextPartID, type: "text", text: commandAfterText },
+        commandPart(delayedCommand, "completed"),
+      ],
+      created_at: commandAfterTextCreatedAt,
+      updated_at: Date.now(),
+    });
+    session = { ...session, status: "idle", updated_at: Date.now() };
+    gatewayEvent("session.status", { sessionID, status: "idle" });
+    await waitForComposer(page);
+    await delay(250);
+    captures.push(await capture(page, "15-command-after-stable-text"));
+    const commandAfterTextBuffer = await terminalBufferText(page);
+    for (const line of commandAfterTextLines) {
+      assert.equal(
+        markerCount(commandAfterTextBuffer, line),
+        1,
+        `${line} must not be duplicated when a later command makes its message live`,
+      );
+    }
+
+    // Phase 9: Markdown headings must have identical marker-free bold
     // presentation while live and after the durable message replaces the feed.
     gatewayEvent("session.status", { sessionID, status: "busy" });
     const headingMessageID = "msg-heading-handoff";
@@ -957,7 +1028,7 @@ async function main() {
     session = { ...session, status: "idle", updated_at: Date.now() };
     gatewayEvent("session.status", { sessionID, status: "idle" });
     await waitForComposer(page);
-    captures.push(await capture(page, "15-heading-handoff-final"));
+    captures.push(await capture(page, "16-heading-handoff-final"));
     const headingBuffer = await terminalBufferText(page);
     assert.equal(await terminalMarkerIsBold(page, "TUI_PRIMARY_HEADING"), true);
     assert.equal(await terminalMarkerIsBold(page, "TUI_SECONDARY_HEADING"), true);

--- a/apps/tui/tests/unit/tui/render-transcript-cache.test.ts
+++ b/apps/tui/tests/unit/tui/render-transcript-cache.test.ts
@@ -262,7 +262,7 @@ test("completed user and assistant turn moves from live into transcript cache", 
   assert.doesNotMatch(liveRows, /CACHE_USER_TEXT|CACHE_AGENT_TEXT/);
 });
 
-test("render cache absorbs stable messages that precede the active live message", () => {
+test("render cache keeps newly stable messages in the active live tail", () => {
   const session = {
     id: "sess-growing-live-cache",
     title: "Growing Live Cache",
@@ -282,11 +282,11 @@ test("render cache absorbs stable messages that precede the active live message"
   const handoff = renderChatFrameParts(state, richCapabilities(), { cache: first.cache });
   const steady = renderChatFrameParts(state, richCapabilities(), { cache: handoff.cache });
 
-  assert.equal(handoff.tailCacheMessageCount, 1);
-  assert.equal(handoff.cache.cacheMessageCount, 1);
+  assert.equal(handoff.tailCacheMessageCount, 0);
+  assert.equal(handoff.cache.cacheMessageCount, 0);
   assert.equal(steady.tailCacheMessageCount, 0);
-  assert.match(stripAnsi(steady.cacheFrame), /FIRST_LIVE_MESSAGE/);
-  assert.doesNotMatch(stripAnsi(steady.liveFrame), /FIRST_LIVE_MESSAGE/);
+  assert.doesNotMatch(stripAnsi(steady.cacheFrame), /FIRST_LIVE_MESSAGE/);
+  assert.match(stripAnsi(steady.liveFrame), /FIRST_LIVE_MESSAGE/);
   assert.match(stripAnsi(steady.liveFrame), /SECOND_LIVE_MESSAGE/);
 
   function liveDelta(messageID: string, delta: string, updatedAt: number) {
@@ -309,6 +309,82 @@ test("render cache absorbs stable messages that precede the active live message"
       },
     };
   }
+});
+
+test("completed commands stay in the mutable tail until a long final response finalizes", () => {
+  const session = {
+    id: "sess-command-final-tail",
+    title: "Command Final Tail",
+    status: "busy" as const,
+  };
+  const commandMessage = (status: "running" | "completed") => ({
+    id: "msg-command-final-tail",
+    sessionID: session.id,
+    role: "assistant" as const,
+    created_at: 1_000,
+    parts: [
+      {
+        id: "part-command-final-tail",
+        type: "tool" as const,
+        tool: "command_run",
+        state: {
+          status,
+          input: {
+            commands: [
+              {
+                step: 1,
+                command_type: "shell_command",
+                command_line: "npm run recent-command",
+              },
+            ],
+          },
+        },
+      },
+    ],
+  });
+  let state = reducer(initialState("C:/repo"), {
+    type: "hydrate",
+    session,
+    messages: [commandMessage("running")],
+    permissions: [],
+    sessions: [session],
+  });
+  state = reducer(state, {
+    type: "event",
+    event: {
+      directory: "C:/repo",
+      payload: {
+        type: "message.part.delta",
+        properties: {
+          sessionID: session.id,
+          messageID: "msg-long-final-tail",
+          partID: "part-long-final-tail",
+          createdAt: 2_000,
+          updatedAt: 2_001,
+          field: "text",
+          delta: Array.from({ length: 36 }, (_, index) => `FINAL_TAIL_LINE_${index + 1}`).join(
+            "\n",
+          ),
+        },
+      },
+    },
+  });
+  const running = renderChatFrameParts(state, richCapabilities());
+  state = reducer(state, {
+    type: "hydrate",
+    session,
+    messages: [commandMessage("completed")],
+    permissions: [],
+    sessions: [session],
+  });
+  const completed = renderChatFrameParts(state, richCapabilities(), { cache: running.cache });
+  const cache = stripAnsi(completed.cacheFrame);
+  const live = stripAnsi(completed.liveFrame);
+
+  assert.equal(completed.tailCacheMessageCount, 0);
+  assert.equal(completed.cache.cacheMessageCount, 0);
+  assert.doesNotMatch(cache, /recent-command|FINAL_TAIL_LINE/u);
+  assert.match(live, /recent-command[\s\S]*FINAL_TAIL_LINE_1[\s\S]*FINAL_TAIL_LINE_36/u);
 });
 
 test("live assistant text keeps event order before a later user message", () => {

--- a/apps/tui/tests/unit/tui/render-transcript-cache.test.ts
+++ b/apps/tui/tests/unit/tui/render-transcript-cache.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { initialState, reducer } from "../../../src/tui/reducer.js";
 import { render, renderChatFrameParts } from "../../../src/tui/render.js";
-import { transcriptLines, transcriptLiveLines } from "../../../src/tui/render/transcript.js";
+import {
+  transcriptLines,
+  transcriptLiveLines,
+  transcriptMessageGroups,
+} from "../../../src/tui/render/transcript.js";
 import { plainCapabilities, richCapabilities } from "../../../src/tui/capabilities.js";
 import { stripAnsi } from "../../../src/tui/render-terminal.js";
 import {
@@ -260,6 +264,89 @@ test("completed user and assistant turn moves from live into transcript cache", 
 
   assert.match(cachedHistory, /CACHE_USER_TEXT[\s\S]*CACHE_AGENT_TEXT/);
   assert.doesNotMatch(liveRows, /CACHE_USER_TEXT|CACHE_AGENT_TEXT/);
+});
+
+test("busy assistant text never moves from cache back into live when its command starts", () => {
+  const session = {
+    id: "sess-stable-text-before-command",
+    title: "Stable Text Before Command",
+    status: "busy" as const,
+  };
+  const textPart = {
+    id: "part-stable-text-before-command",
+    type: "text" as const,
+    text: Array.from(
+      { length: 36 },
+      (_item, index) => `STABLE_BEFORE_COMMAND_${String(index + 1).padStart(2, "0")}`,
+    ).join("\n"),
+  };
+  const userMessage = {
+    id: "msg-user-stable-before-command",
+    sessionID: session.id,
+    role: "user" as const,
+    created_at: 1_000,
+    parts: [{ id: "part-user-stable-before-command", type: "text" as const, text: "run it" }],
+  };
+  const assistantMessage = (status?: "running") => ({
+    id: "msg-stable-before-command",
+    sessionID: session.id,
+    role: "assistant" as const,
+    created_at: 2_000,
+    parts: [
+      textPart,
+      ...(status
+        ? [
+            {
+              id: "part-command-after-stable-text",
+              type: "tool" as const,
+              tool: "command_run",
+              state: {
+                status,
+                input: {
+                  commands: [
+                    {
+                      step: 1,
+                      command_type: "shell_command",
+                      command_line: "git log --since=3.days --stat",
+                    },
+                  ],
+                },
+              },
+            },
+          ]
+        : []),
+    ],
+  });
+  let state = reducer(initialState("C:/repo"), {
+    type: "hydrate",
+    session,
+    messages: [userMessage, assistantMessage()],
+    permissions: [],
+    sessions: [session],
+  });
+
+  const textOnly = renderChatFrameParts(state, richCapabilities());
+  state = reducer(state, {
+    type: "event",
+    event: {
+      directory: "C:/repo",
+      payload: {
+        type: "message.updated",
+        properties: { sessionID: session.id, info: assistantMessage("running") },
+      },
+    },
+  });
+  const commandRunning = renderChatFrameParts(state, richCapabilities(), { cache: textOnly.cache });
+
+  assert.match(stripAnsi(textOnly.cacheFrame), /run it/u);
+  assert.doesNotMatch(stripAnsi(textOnly.cacheFrame), /STABLE_BEFORE_COMMAND/u);
+  assert.match(
+    stripAnsi(textOnly.liveFrame),
+    /STABLE_BEFORE_COMMAND_01[\s\S]*STABLE_BEFORE_COMMAND_36/u,
+  );
+  assert.equal(commandRunning.cache.cacheMessageCount, textOnly.cache.cacheMessageCount);
+  assert.doesNotMatch(stripAnsi(commandRunning.cacheFrame), /STABLE_BEFORE_COMMAND/u);
+  assert.match(stripAnsi(commandRunning.liveFrame), /STABLE_BEFORE_COMMAND_01[\s\S]*Commands/u);
 });
 
 test("render cache keeps newly stable messages in the active live tail", () => {
@@ -554,6 +641,14 @@ test("runtime message stays live while its command is still running", () => {
     },
   });
 
+  assert.deepEqual(
+    transcriptMessageGroups(state).cache.map((message) => message.id),
+    ["msg-runtime-live-user"],
+  );
+  assert.deepEqual(
+    transcriptMessageGroups(state).live.map((message) => message.id),
+    ["runtime-live.message"],
+  );
   cacheRows = stripAnsi(transcriptLines(state, 100).join("\n"));
   liveRows = stripAnsi(transcriptLiveLines(state, 100).join("\n"));
   assert.doesNotMatch(cacheRows, /I will run the checks/);
@@ -604,9 +699,9 @@ test("runtime message stays live while its command is still running", () => {
 
   cacheRows = stripAnsi(transcriptLines(state, 100).join("\n"));
   liveRows = stripAnsi(transcriptLiveLines(state, 100).join("\n"));
-  assert.match(cacheRows, /I will run the checks/);
-  assert.match(cacheRows, /npm test/);
-  assert.doesNotMatch(liveRows, /I will run the checks|npm test/);
+  assert.doesNotMatch(cacheRows, /I will run the checks|npm test/);
+  assert.match(liveRows, /I will run the checks/);
+  assert.match(liveRows, /npm test/);
 
   state = reducer(state, {
     type: "messages-incremental",
@@ -643,6 +738,16 @@ test("runtime message stays live while its command is still running", () => {
         ],
       },
     ],
+  });
+  state = reducer(state, {
+    type: "event",
+    event: {
+      directory: "C:/repo",
+      payload: {
+        type: "session.status",
+        properties: { sessionID: session.id, updatedAt: 1_800, status: "idle" },
+      },
+    },
   });
 
   cacheRows = stripAnsi(transcriptLines(state, 100).join("\n"));

--- a/commands/generate_media/mod.rs
+++ b/commands/generate_media/mod.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::unwrap_used)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/commands/generate_media/src/args.rs
+++ b/commands/generate_media/src/args.rs
@@ -156,12 +156,12 @@ pub(super) fn parse_cli_args(input: &str) -> Result<GenerateMediaArgs, String> {
             index += 1;
             continue;
         }
-        if index == 0 {
-            if let Ok(kind) = parse_media_kind(original_word) {
-                parts.kind = Some(kind);
-                index += 1;
-                continue;
-            }
+        if index == 0
+            && let Ok(kind) = parse_media_kind(original_word)
+        {
+            parts.kind = Some(kind);
+            index += 1;
+            continue;
         }
         let (word, inline_value) = split_cli_assignment(original_word);
         let take_value = |index: &mut usize| -> Result<String, String> {
@@ -530,10 +530,10 @@ fn is_generate_media_command_name(value: &str) -> bool {
 }
 
 fn split_cli_assignment(word: &str) -> (String, Option<String>) {
-    if let Some((key, value)) = word.split_once('=') {
-        if key.starts_with('-') {
-            return (key.to_string(), Some(value.to_string()));
-        }
+    if let Some((key, value)) = word.split_once('=')
+        && key.starts_with('-')
+    {
+        return (key.to_string(), Some(value.to_string()));
     }
     (word.to_string(), None)
 }
@@ -607,7 +607,7 @@ fn string_list_field(object: &serde_json::Map<String, Value>, keys: &[&str]) -> 
                         .iter()
                         .filter_map(Value::as_str)
                         .flat_map(split_csv)
-                        .collect()
+                        .collect();
                 }
                 Value::String(text) => return split_csv(text),
                 _ => {}

--- a/commands/generate_media/src/config.rs
+++ b/commands/generate_media/src/config.rs
@@ -261,14 +261,14 @@ fn current_dir_dotenv_value(name: &str) -> Option<String> {
     let mut dir = std::env::current_dir().ok()?;
     loop {
         let env_path = dir.join(".env");
-        if env_path.exists() {
-            if let Ok(entries) = from_path_iter(&env_path) {
-                for (key, value) in entries.flatten() {
-                    if key.to_ascii_uppercase() == upper {
-                        let value = value.trim().to_string();
-                        if !value.is_empty() {
-                            return Some(value);
-                        }
+        if env_path.exists()
+            && let Ok(entries) = from_path_iter(&env_path)
+        {
+            for (key, value) in entries.flatten() {
+                if key.to_ascii_uppercase() == upper {
+                    let value = value.trim().to_string();
+                    if !value.is_empty() {
+                        return Some(value);
                     }
                 }
             }
@@ -300,17 +300,17 @@ pub(super) fn openai_auth_candidates() -> Result<Vec<OpenAiAuth>, String> {
         });
     }
 
-    if let Some((token, codex_account_id)) = load_codex_auth_json() {
-        if !seen.contains(&token) {
-            seen.push(token.clone());
-            candidates.push(OpenAiAuth::CodexOAuth {
-                account_id: account_id
-                    .clone()
-                    .or(codex_account_id)
-                    .or_else(|| account_id_from_oauth_token(&token)),
-                token,
-            });
-        }
+    if let Some((token, codex_account_id)) = load_codex_auth_json()
+        && !seen.contains(&token)
+    {
+        seen.push(token.clone());
+        candidates.push(OpenAiAuth::CodexOAuth {
+            account_id: account_id
+                .clone()
+                .or(codex_account_id)
+                .or_else(|| account_id_from_oauth_token(&token)),
+            token,
+        });
     }
 
     for key in [

--- a/commands/generate_media/src/providers.rs
+++ b/commands/generate_media/src/providers.rs
@@ -576,10 +576,10 @@ fn parse_codex_responses_response(
 fn collect_codex_image_results(value: &Value, results: &mut Vec<String>) {
     match value {
         Value::Object(map) => {
-            if map.get("type").and_then(Value::as_str) == Some("image_generation_call") {
-                if let Some(result) = map.get("result").and_then(Value::as_str) {
-                    results.push(result.to_string());
-                }
+            if map.get("type").and_then(Value::as_str) == Some("image_generation_call")
+                && let Some(result) = map.get("result").and_then(Value::as_str)
+            {
+                results.push(result.to_string());
             }
             for nested in map.values() {
                 collect_codex_image_results(nested, results);

--- a/commands/generate_media/src/runner.rs
+++ b/commands/generate_media/src/runner.rs
@@ -230,10 +230,10 @@ fn strip_large_base64(value: &mut Value) {
     match value {
         Value::Object(object) => {
             for key in ["b64_json", "data"] {
-                if let Some(Value::String(text)) = object.get_mut(key) {
-                    if text.len() > 256 {
-                        *text = format!("[base64 omitted: {} chars]", text.len());
-                    }
+                if let Some(Value::String(text)) = object.get_mut(key)
+                    && text.len() > 256
+                {
+                    *text = format!("[base64 omitted: {} chars]", text.len());
                 }
             }
             for child in object.values_mut() {

--- a/commands/generate_media/src/tests.rs
+++ b/commands/generate_media/src/tests.rs
@@ -50,8 +50,22 @@ fn uses_configured_provider_order_and_output_dir_when_unspecified() {
     let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
     let previous_order = std::env::var("TURA_GENERATE_MEDIA_PROVIDER_ORDER").ok();
     let previous_dir = std::env::var("TURA_GENERATE_MEDIA_OUTPUT_DIRECTORY").ok();
-    std::env::set_var("TURA_GENERATE_MEDIA_PROVIDER_ORDER", "gemini,grok3");
-    std::env::set_var("TURA_GENERATE_MEDIA_OUTPUT_DIRECTORY", "configured/images");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_GENERATE_MEDIA_PROVIDER_ORDER", "gemini,grok3")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_GENERATE_MEDIA_OUTPUT_DIRECTORY", "configured/images")
+    };
 
     let args = parse_args_text("--prompt poster").expect("parse configured defaults");
 
@@ -112,7 +126,25 @@ fn parses_azure_speech_and_legacy_free_alias_separately() {
 
 fn restore_env(key: &str, value: Option<String>) {
     match value {
-        Some(value) => std::env::set_var(key, value),
-        None => std::env::remove_var(key),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            }
+        }
     }
 }

--- a/commands/generate_media/tests/business/generate_media_local_flow.rs
+++ b/commands/generate_media/tests/business/generate_media_local_flow.rs
@@ -797,17 +797,49 @@ fn clear_speech_provider_env(provider: &str) {
 }
 
 fn set_env(key: &str, value: &str) {
-    std::env::set_var(key, value);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var(key, value)
+    };
 }
 
 fn clear_env(key: &str) {
-    std::env::remove_var(key);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var(key)
+    };
 }
 
 fn restore_env(key: &str, value: Option<String>) {
     match value {
-        Some(value) => std::env::set_var(key, value),
-        None => std::env::remove_var(key),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            }
+        }
     }
 }
 
@@ -824,7 +856,14 @@ impl DotenvIsolation {
         std::fs::write(&env_path, "").expect("write isolated dotenv");
         let previous_env_path = std::env::var_os("TURA_ENV_PATH");
         let previous_current_dir = std::env::current_dir().expect("current dir");
-        std::env::set_var("TURA_ENV_PATH", &env_path);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_ENV_PATH", &env_path)
+        };
         std::env::set_current_dir(temp.path()).expect("set isolated current dir");
         Self {
             previous_env_path,
@@ -838,8 +877,26 @@ impl Drop for DotenvIsolation {
     fn drop(&mut self) {
         let _ = std::env::set_current_dir(&self.previous_current_dir);
         match &self.previous_env_path {
-            Some(value) => std::env::set_var("TURA_ENV_PATH", value),
-            None => std::env::remove_var("TURA_ENV_PATH"),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("TURA_ENV_PATH", value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var("TURA_ENV_PATH")
+                }
+            }
         }
     }
 }

--- a/commands/read_media/mod.rs
+++ b/commands/read_media/mod.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::unwrap_used)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/commands/read_media/src/args.rs
+++ b/commands/read_media/src/args.rs
@@ -233,10 +233,10 @@ fn is_read_media_command_name(value: &str) -> bool {
 }
 
 fn split_cli_assignment(word: &str) -> (String, Option<String>) {
-    if let Some((key, value)) = word.split_once('=') {
-        if key.starts_with('-') {
-            return (key.to_string(), Some(value.to_string()));
-        }
+    if let Some((key, value)) = word.split_once('=')
+        && key.starts_with('-')
+    {
+        return (key.to_string(), Some(value.to_string()));
     }
     (word.to_string(), None)
 }

--- a/commands/read_media/src/pdf.rs
+++ b/commands/read_media/src/pdf.rs
@@ -55,10 +55,11 @@ pub(super) fn process_pdf(
             }));
         }
     }
-    if args.include_text && text.trim().is_empty() {
-        if let Ok(fallback) = fallback_pdf_text(path, args) {
-            text = fallback;
-        }
+    if args.include_text
+        && text.trim().is_empty()
+        && let Ok(fallback) = fallback_pdf_text(path, args)
+    {
+        text = fallback;
     }
     Ok((truncate_chars(&text, args.max_text_chars), previews))
 }
@@ -73,10 +74,9 @@ fn fallback_pdf_text(path: &Path, args: &ReadMediaArgs) -> Result<String, String
     }
     if let Ok(text) =
         extract_pdf_text_with_python_fitz(path, args.max_text_chars, args.pdf_max_pages)
+        && !text.trim().is_empty()
     {
-        if !text.trim().is_empty() {
-            return Ok(text);
-        }
+        return Ok(text);
     }
     let bytes = std::fs::read(path).map_err(|err| format!("failed to read pdf: {err}"))?;
     let raw = String::from_utf8_lossy(&bytes);

--- a/commands/read_media/src/video.rs
+++ b/commands/read_media/src/video.rs
@@ -221,10 +221,11 @@ print(json.dumps(frames))
 
 pub(super) fn resolve_ffmpeg() -> Option<String> {
     for env_name in ["TURA_READ_MEDIA_FFMPEG", "FFMPEG_PATH"] {
-        if let Ok(path) = std::env::var(env_name) {
-            if !path.trim().is_empty() && Path::new(&path).exists() {
-                return Some(path);
-            }
+        if let Ok(path) = std::env::var(env_name)
+            && !path.trim().is_empty()
+            && Path::new(&path).exists()
+        {
+            return Some(path);
         }
     }
     resolve_imageio_ffmpeg()
@@ -276,9 +277,23 @@ mod tests {
 
     fn restore_env(key: &str, value: Option<OsString>) {
         if let Some(value) = value {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         } else {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 
@@ -322,19 +337,47 @@ mod tests {
         let previous_python = std::env::var_os("TURA_READ_MEDIA_PYTHON");
         let previous_command_python = std::env::var_os("TURA_COMMAND_PYTHON");
 
-        std::env::remove_var("FFMPEG_PATH");
-        std::env::set_var(
-            "TURA_READ_MEDIA_PYTHON",
-            "definitely-missing-python-for-read-media",
-        );
-        std::env::set_var(
-            "TURA_COMMAND_PYTHON",
-            "definitely-missing-python-for-read-media",
-        );
-        std::env::set_var(
-            "TURA_READ_MEDIA_FFMPEG",
-            "definitely-missing-ffmpeg-for-read-media",
-        );
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("FFMPEG_PATH")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(
+                "TURA_READ_MEDIA_PYTHON",
+                "definitely-missing-python-for-read-media",
+            )
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(
+                "TURA_COMMAND_PYTHON",
+                "definitely-missing-python-for-read-media",
+            )
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(
+                "TURA_READ_MEDIA_FFMPEG",
+                "definitely-missing-ffmpeg-for-read-media",
+            )
+        };
         let missing = resolve_ffmpeg();
         if let Some(path) = missing.as_deref() {
             assert!(
@@ -344,7 +387,14 @@ mod tests {
         }
 
         let (_dir, fake) = fake_ffmpeg_script(true);
-        std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake)
+        };
         assert_eq!(
             resolve_ffmpeg().as_deref(),
             Some(fake.to_string_lossy().as_ref())
@@ -363,8 +413,22 @@ mod tests {
         let previous_ffmpeg_path = std::env::var_os("FFMPEG_PATH");
         let (_dir, fake) = fake_ffmpeg_script(false);
         let media = tempfile::NamedTempFile::new().expect("media file");
-        std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake);
-        std::env::remove_var("FFMPEG_PATH");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("FFMPEG_PATH")
+        };
 
         let error = process_audio(media.path(), &args(123_456)).expect_err("ffmpeg should fail");
 

--- a/commands/read_media/tests/business/read_media_local_flow.rs
+++ b/commands/read_media/tests/business/read_media_local_flow.rs
@@ -463,8 +463,22 @@ fn read_media_business_flow_extracts_audio_preview_with_local_ffmpeg_and_clamped
     let fake_ffmpeg = write_fake_ffmpeg(dir.path());
     let previous_ffmpeg = std::env::var_os("TURA_READ_MEDIA_FFMPEG");
     let previous_ffmpeg_path = std::env::var_os("FFMPEG_PATH");
-    std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake_ffmpeg);
-    std::env::remove_var("FFMPEG_PATH");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake_ffmpeg)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("FFMPEG_PATH")
+    };
     std::fs::write(dir.path().join("voice.mp3"), b"local fake source audio").expect("write mp3");
 
     let response = execute(
@@ -511,8 +525,22 @@ fn read_media_business_protocol_audio_preview_uses_local_ffmpeg_across_process_b
     let fake_ffmpeg = write_fake_ffmpeg(dir.path());
     let previous_ffmpeg = std::env::var_os("TURA_READ_MEDIA_FFMPEG");
     let previous_ffmpeg_path = std::env::var_os("FFMPEG_PATH");
-    std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake_ffmpeg);
-    std::env::remove_var("FFMPEG_PATH");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake_ffmpeg)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("FFMPEG_PATH")
+    };
     std::fs::write(
         dir.path().join("protocol-audio.mp3"),
         b"protocol fake source audio",
@@ -585,8 +613,22 @@ fn read_media_business_flow_extracts_video_frames_and_audio_preview_with_local_f
     let fake_ffmpeg = write_fake_ffmpeg(dir.path());
     let previous_ffmpeg = std::env::var_os("TURA_READ_MEDIA_FFMPEG");
     let previous_ffmpeg_path = std::env::var_os("FFMPEG_PATH");
-    std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake_ffmpeg);
-    std::env::remove_var("FFMPEG_PATH");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake_ffmpeg)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("FFMPEG_PATH")
+    };
     std::fs::write(dir.path().join("clip.mp4"), b"local fake video bytes").expect("write mp4");
 
     let response = execute(
@@ -638,9 +680,30 @@ fn read_media_business_flow_reports_video_failure_from_local_ffmpeg_and_cv2_fall
     let previous_ffmpeg = std::env::var_os("TURA_READ_MEDIA_FFMPEG");
     let previous_ffmpeg_path = std::env::var_os("FFMPEG_PATH");
     let previous_python = std::env::var_os("TURA_READ_MEDIA_PYTHON");
-    std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake_ffmpeg);
-    std::env::remove_var("FFMPEG_PATH");
-    std::env::set_var("TURA_READ_MEDIA_PYTHON", &fake_python);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake_ffmpeg)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("FFMPEG_PATH")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_READ_MEDIA_PYTHON", &fake_python)
+    };
     std::fs::write(dir.path().join("broken.mp4"), b"broken fake video").expect("write broken mp4");
 
     let response = execute(
@@ -681,8 +744,22 @@ fn read_media_business_flow_mixed_batch_workers_keep_order_and_isolate_failures(
     let fake_ffmpeg = write_fake_ffmpeg(dir.path());
     let previous_ffmpeg = std::env::var_os("TURA_READ_MEDIA_FFMPEG");
     let previous_ffmpeg_path = std::env::var_os("FFMPEG_PATH");
-    std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake_ffmpeg);
-    std::env::remove_var("FFMPEG_PATH");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_READ_MEDIA_FFMPEG", &fake_ffmpeg)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("FFMPEG_PATH")
+    };
 
     std::fs::write(dir.path().join("notes.txt"), "mixed batch notes").expect("write notes");
     std::fs::write(dir.path().join("image.png"), png_bytes()).expect("write png");
@@ -987,7 +1064,25 @@ fn env_lock() -> &'static Mutex<()> {
 
 fn restore_env(key: &str, previous: Option<std::ffi::OsString>) {
     match previous {
-        Some(value) => std::env::set_var(key, value),
-        None => std::env::remove_var(key),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            }
+        }
     }
 }

--- a/commands/web_discover/mod.rs
+++ b/commands/web_discover/mod.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::unwrap_used)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/commands/web_discover/src/args.rs
+++ b/commands/web_discover/src/args.rs
@@ -195,10 +195,10 @@ pub(super) fn is_kind_word(value: &str) -> bool {
 }
 
 pub(super) fn split_cli_assignment(word: &str) -> (String, Option<String>) {
-    if let Some((key, value)) = word.split_once('=') {
-        if key.starts_with('-') {
-            return (key.to_string(), Some(value.to_string()));
-        }
+    if let Some((key, value)) = word.split_once('=')
+        && key.starts_with('-')
+    {
+        return (key.to_string(), Some(value.to_string()));
     }
     (word.to_string(), None)
 }

--- a/commands/web_discover/src/asset.rs
+++ b/commands/web_discover/src/asset.rs
@@ -248,21 +248,19 @@ fn enrich_asset_candidate(
         license: None,
     };
 
-    if candidate.download_url.is_none() {
-        if let Some(page_url) = candidate.page_url.clone() {
-            if let Some(enriched) =
-                extract_downloadable_asset_from_page(client, &page_url, &source_query.asset_type)
-            {
-                candidate.download_url = Some(enriched.url);
-                candidate.license = enriched.license;
-                candidate.asset_type = classify_asset_type(
-                    candidate.download_url.as_deref().unwrap_or_default(),
-                    &candidate.title,
-                    Some(source_query.source),
-                    &source_query.asset_type,
-                );
-            }
-        }
+    if candidate.download_url.is_none()
+        && let Some(page_url) = candidate.page_url.clone()
+        && let Some(enriched) =
+            extract_downloadable_asset_from_page(client, &page_url, &source_query.asset_type)
+    {
+        candidate.download_url = Some(enriched.url);
+        candidate.license = enriched.license;
+        candidate.asset_type = classify_asset_type(
+            candidate.download_url.as_deref().unwrap_or_default(),
+            &candidate.title,
+            Some(source_query.source),
+            &source_query.asset_type,
+        );
     }
 
     candidate
@@ -363,10 +361,11 @@ fn extract_asset_links(html: &str, base_url: &str, fallback_type: &str) -> Vec<S
         let decoded = html_unescape(&json_unescape(candidate))
             .replace("\\u002F", "/")
             .replace("\\/", "/");
-        if let Some(url) = resolve_page_url(base_url, &decoded) {
-            if asset_url_matches_type(&url, fallback_type) && seen.insert(url.clone()) {
-                out.push(url);
-            }
+        if let Some(url) = resolve_page_url(base_url, &decoded)
+            && asset_url_matches_type(&url, fallback_type)
+            && seen.insert(url.clone())
+        {
+            out.push(url);
         }
     };
 

--- a/commands/web_discover/src/download.rs
+++ b/commands/web_discover/src/download.rs
@@ -230,10 +230,11 @@ pub(super) fn ytdlp_download_candidate_rank(
 
 pub(super) fn resolve_ytdlp_command() -> (String, Vec<String>) {
     for env_name in ["TURA_WEB_DISCOVER_YTDLP", "TURA_YTDLP", "YTDLP_PATH"] {
-        if let Ok(path) = std::env::var(env_name) {
-            if !path.trim().is_empty() && Path::new(&path).exists() {
-                return (path, Vec::new());
-            }
+        if let Ok(path) = std::env::var(env_name)
+            && !path.trim().is_empty()
+            && Path::new(&path).exists()
+        {
+            return (path, Vec::new());
         }
     }
     if let Some(path) = command_local_executable("yt-dlp") {

--- a/commands/web_discover/src/html.rs
+++ b/commands/web_discover/src/html.rs
@@ -158,10 +158,10 @@ pub(super) fn extract_media_links(html: &str, base_url: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut seen = std::collections::HashSet::new();
     let mut push = |candidate: &str| {
-        if let Some(url) = normalize_media_url(candidate, base_url) {
-            if seen.insert(url.clone()) {
-                out.push(url);
-            }
+        if let Some(url) = normalize_media_url(candidate, base_url)
+            && seen.insert(url.clone())
+        {
+            out.push(url);
         }
     };
 

--- a/commands/web_discover/src/runner.rs
+++ b/commands/web_discover/src/runner.rs
@@ -48,36 +48,36 @@ pub(super) fn run_web_discover_inner(
         normalized_query.clone()
     };
     let output_dir = Some(resolve_download_dir(&args, session_dir)?);
-    if args.kind == "website" {
-        if let Some(url) = direct_webpage_url(&args.query) {
-            let result = SearchResult {
-                title: title_from_url(&url),
-                url,
-                snippet: "Direct webpage fetch from query URL.".to_string(),
-                source: "direct_url".to_string(),
-                page_url: None,
-            };
-            let (records, downloaded_files) = website_records(
-                &client,
-                &[result],
-                should_download,
-                output_dir.as_deref(),
-                session_dir,
-            )?;
-            let output = json!({
-                "query": args.query,
-                "type": args.kind,
-                "normalized_query": normalized_query,
-                "direct_fetch": true,
-                "saved": should_download,
-                "download_dir": output_dir.as_deref().map(|path| relative_or_display(path, session_dir)),
-                "result_count": records.len(),
-                "results": records,
-                "downloaded_files": downloaded_files,
-                "summary_markdown": summarize_records(&records, &downloaded_files),
-            });
-            return Ok(output);
-        }
+    if args.kind == "website"
+        && let Some(url) = direct_webpage_url(&args.query)
+    {
+        let result = SearchResult {
+            title: title_from_url(&url),
+            url,
+            snippet: "Direct webpage fetch from query URL.".to_string(),
+            source: "direct_url".to_string(),
+            page_url: None,
+        };
+        let (records, downloaded_files) = website_records(
+            &client,
+            &[result],
+            should_download,
+            output_dir.as_deref(),
+            session_dir,
+        )?;
+        let output = json!({
+            "query": args.query,
+            "type": args.kind,
+            "normalized_query": normalized_query,
+            "direct_fetch": true,
+            "saved": should_download,
+            "download_dir": output_dir.as_deref().map(|path| relative_or_display(path, session_dir)),
+            "result_count": records.len(),
+            "results": records,
+            "downloaded_files": downloaded_files,
+            "summary_markdown": summarize_records(&records, &downloaded_files),
+        });
+        return Ok(output);
     }
     if args.kind == "asset" {
         let (records, downloaded_files, searched_sources) = asset_records(

--- a/commands/web_discover/src/search.rs
+++ b/commands/web_discover/src/search.rs
@@ -22,10 +22,9 @@ pub(super) fn search_websites(
 ) -> Result<Vec<SearchResult>, String> {
     if let Some(endpoint) =
         env_value("TURA_WEB_DISCOVER_ENDPOINT").or_else(|| env_value("TURA_WEB_SEARCH_ENDPOINT"))
+        && let Ok(results) = search_custom_endpoint(client, &endpoint, query, limit)
     {
-        if let Ok(results) = search_custom_endpoint(client, &endpoint, query, limit) {
-            return Ok(results);
-        }
+        return Ok(results);
     }
     let mut errors = Vec::new();
     for route in configured_search_routes() {
@@ -174,21 +173,21 @@ pub(super) fn parse_exa_web_results(raw: &str, limit: usize) -> Result<Vec<Searc
         for line in block.lines().chain(std::iter::once("---")) {
             let trimmed = line.trim();
             if trimmed == "---" {
-                if let Some(url) = current_url.take() {
-                    if seen.insert(url.clone()) {
-                        out.push(SearchResult {
-                            title: current_title
-                                .take()
-                                .filter(|title| !title.is_empty())
-                                .unwrap_or_else(|| "Exa web result".to_string()),
-                            url,
-                            page_url: None,
-                            snippet: truncate_chars(&clean_text(&current_snippet.join(" ")), 1_000),
-                            source: "exa_web".to_string(),
-                        });
-                        if out.len() >= limit {
-                            break;
-                        }
+                if let Some(url) = current_url.take()
+                    && seen.insert(url.clone())
+                {
+                    out.push(SearchResult {
+                        title: current_title
+                            .take()
+                            .filter(|title| !title.is_empty())
+                            .unwrap_or_else(|| "Exa web result".to_string()),
+                        url,
+                        page_url: None,
+                        snippet: truncate_chars(&clean_text(&current_snippet.join(" ")), 1_000),
+                        source: "exa_web".to_string(),
+                    });
+                    if out.len() >= limit {
+                        break;
                     }
                 }
                 current_title = None;
@@ -448,28 +447,28 @@ pub(super) fn search_bing_image_links(
             }
         }
     }
-    if out.len() < limit {
-        if let Ok(re) = Regex::new(r#"mediaurl=([^&"'>\s]+)"#) {
-            for capture in re.captures_iter(&html) {
-                let context_start = capture.get(0).map(|m| m.start()).unwrap_or(0);
-                let context_end = html.len().min(context_start + 2_500);
-                let context = &html[context_start..context_end];
-                let url = percent_decode(capture.get(1).map(|v| v.as_str()).unwrap_or_default());
-                if !url.starts_with("http") || !seen.insert(url.clone()) {
-                    continue;
-                }
-                let page_url = extract_bing_image_page_url(context);
-                let title = extract_bing_image_title(context, page_url.as_deref(), &url);
-                out.push(SearchResult {
-                    title,
-                    url,
-                    page_url: page_url.clone(),
-                    snippet: page_url.clone().unwrap_or_default(),
-                    source: "bing_images_mediaurl".to_string(),
-                });
-                if out.len() >= limit {
-                    break;
-                }
+    if out.len() < limit
+        && let Ok(re) = Regex::new(r#"mediaurl=([^&"'>\s]+)"#)
+    {
+        for capture in re.captures_iter(&html) {
+            let context_start = capture.get(0).map(|m| m.start()).unwrap_or(0);
+            let context_end = html.len().min(context_start + 2_500);
+            let context = &html[context_start..context_end];
+            let url = percent_decode(capture.get(1).map(|v| v.as_str()).unwrap_or_default());
+            if !url.starts_with("http") || !seen.insert(url.clone()) {
+                continue;
+            }
+            let page_url = extract_bing_image_page_url(context);
+            let title = extract_bing_image_title(context, page_url.as_deref(), &url);
+            out.push(SearchResult {
+                title,
+                url,
+                page_url: page_url.clone(),
+                snippet: page_url.clone().unwrap_or_default(),
+                source: "bing_images_mediaurl".to_string(),
+            });
+            if out.len() >= limit {
+                break;
             }
         }
     }
@@ -599,10 +598,10 @@ pub(super) fn extract_page_image_url(html: &str, base_url: &str) -> Option<Strin
                     .map(|value| value.as_str())
                     .unwrap_or_default(),
             );
-            if let Some(url) = resolve_page_url(base_url, &candidate) {
-                if looks_like_image_url(&url) {
-                    return Some(url);
-                }
+            if let Some(url) = resolve_page_url(base_url, &candidate)
+                && looks_like_image_url(&url)
+            {
+                return Some(url);
             }
         }
     }
@@ -921,8 +920,26 @@ mod tests {
         fn drop(&mut self) {
             for (key, value) in &self.keys {
                 match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    Some(value) => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::set_var(key, value)
+                        }
+                    }
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    None => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::remove_var(key)
+                        }
+                    }
                 }
             }
         }
@@ -982,7 +999,14 @@ mod tests {
         })
         .to_string();
         let (endpoint, server) = spawn_http_response("200 OK", "application/json", body);
-        std::env::set_var("TURA_BRAVE_WEB_SEARCH_ENDPOINT", &endpoint);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_BRAVE_WEB_SEARCH_ENDPOINT", &endpoint)
+        };
 
         let results =
             search_brave_web_links(&client(), "rust", 10, "local-key").expect("brave web results");
@@ -1009,7 +1033,14 @@ mod tests {
             "application/json",
             json!({"web":{"results":[]}}).to_string(),
         );
-        std::env::set_var("TURA_BRAVE_WEB_SEARCH_ENDPOINT", &endpoint);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_BRAVE_WEB_SEARCH_ENDPOINT", &endpoint)
+        };
 
         let empty =
             search_brave_web_links(&client(), "rust", 5, "local-key").expect_err("empty results");
@@ -1018,7 +1049,14 @@ mod tests {
 
         let (endpoint, server) =
             spawn_http_response("200 OK", "application/json", "{not json".to_string());
-        std::env::set_var("TURA_BRAVE_WEB_SEARCH_ENDPOINT", &endpoint);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_BRAVE_WEB_SEARCH_ENDPOINT", &endpoint)
+        };
         let invalid =
             search_brave_web_links(&client(), "rust", 5, "local-key").expect_err("bad JSON");
         server.join().expect("server request");
@@ -1049,7 +1087,14 @@ mod tests {
         })
         .to_string();
         let (endpoint, server) = spawn_http_response("200 OK", "application/json", body);
-        std::env::set_var("TURA_BRAVE_IMAGE_SEARCH_ENDPOINT", &endpoint);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_BRAVE_IMAGE_SEARCH_ENDPOINT", &endpoint)
+        };
 
         let results = search_brave_image_links(&client(), "profile", 10, "local-key")
             .expect("brave image results");
@@ -1081,7 +1126,14 @@ mod tests {
         "#
         .to_string();
         let (endpoint, server) = spawn_http_response("200 OK", "text/html", body);
-        std::env::set_var("TURA_IMAGE_SEARCH_ENDPOINT", &endpoint);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_IMAGE_SEARCH_ENDPOINT", &endpoint)
+        };
 
         let results = search_bing_image_links(&client(), "images", 10).expect("bing images");
         let request = server.join().expect("server request");

--- a/commands/web_discover/src/util.rs
+++ b/commands/web_discover/src/util.rs
@@ -86,14 +86,14 @@ pub(super) fn percent_decode(value: &str) -> String {
     let mut out = Vec::with_capacity(bytes.len());
     let mut index = 0usize;
     while index < bytes.len() {
-        if bytes[index] == b'%' && index + 2 < bytes.len() {
-            if let Ok(hex) = std::str::from_utf8(&bytes[index + 1..index + 3]) {
-                if let Ok(byte) = u8::from_str_radix(hex, 16) {
-                    out.push(byte);
-                    index += 3;
-                    continue;
-                }
-            }
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let Ok(hex) = std::str::from_utf8(&bytes[index + 1..index + 3])
+            && let Ok(byte) = u8::from_str_radix(hex, 16)
+        {
+            out.push(byte);
+            index += 3;
+            continue;
         }
         out.push(if bytes[index] == b'+' {
             b' '

--- a/commands/web_discover/src/website.rs
+++ b/commands/web_discover/src/website.rs
@@ -173,10 +173,10 @@ pub(super) fn response_to_website_content(
         .and_then(|value| value.to_str().ok())
         .unwrap_or_default()
         .to_string();
-    if let Some(length) = response.content_length() {
-        if length as usize > MAX_WEBSITE_RESPONSE_SIZE {
-            return Err("response too large (exceeds 5MB limit)".to_string());
-        }
+    if let Some(length) = response.content_length()
+        && length as usize > MAX_WEBSITE_RESPONSE_SIZE
+    {
+        return Err("response too large (exceeds 5MB limit)".to_string());
     }
     let bytes = response
         .bytes()

--- a/commands/web_discover/tests/business/helpers/web_discover_local.rs
+++ b/commands/web_discover/tests/business/helpers/web_discover_local.rs
@@ -636,8 +636,22 @@ pub(crate) fn env_lock() -> &'static Mutex<()> {
 
 pub(crate) fn restore_env(name: &str, value: Option<std::ffi::OsString>) {
     if let Some(value) = value {
-        std::env::set_var(name, value);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(name, value)
+        };
     } else {
-        std::env::remove_var(name);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(name)
+        };
     }
 }

--- a/commands/web_discover/tests/business/web_discover_local_flow.rs
+++ b/commands/web_discover/tests/business/web_discover_local_flow.rs
@@ -412,7 +412,14 @@ fn web_discover_business_flow_downloads_direct_audio_with_local_downloader() {
     let dir = tempfile::tempdir().expect("tempdir");
     let fake_ytdlp = write_fake_ytdlp(dir.path());
     let previous_ytdlp = std::env::var_os("TURA_WEB_DISCOVER_YTDLP");
-    std::env::set_var("TURA_WEB_DISCOVER_YTDLP", &fake_ytdlp);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_DISCOVER_YTDLP", &fake_ytdlp)
+    };
 
     let command_line = r#"{"type":"audio","query":"\"https://www.bilibili.com/video/BV1xx411c7mD\"","download_dir":"audio-out","min_size":1,"max_size":100000}"#;
     let access = access(command_line, dir.path());
@@ -458,7 +465,14 @@ fn web_discover_business_flow_downloads_direct_video_and_uses_unique_names_on_re
     let dir = tempfile::tempdir().expect("tempdir");
     let fake_ytdlp = write_fake_ytdlp(dir.path());
     let previous_ytdlp = std::env::var_os("TURA_WEB_DISCOVER_YTDLP");
-    std::env::set_var("TURA_WEB_DISCOVER_YTDLP", &fake_ytdlp);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_DISCOVER_YTDLP", &fake_ytdlp)
+    };
 
     let command_line = r#"{"type":"video","query":"\"https://www.youtube.com/watch?v=localBusinessVideo\"","download_dir":"video out","min_size":1,"max_size":100000}"#;
     let access = access(command_line, dir.path());
@@ -523,7 +537,14 @@ fn web_discover_business_flow_fetches_plain_text_and_records_failed_fetch_withou
 {
     let _guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
     let previous = std::env::var_os("TURA_WEB_READER_DISABLED");
-    std::env::set_var("TURA_WEB_READER_DISABLED", "true");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_READER_DISABLED", "true")
+    };
 
     let dir = tempfile::tempdir().expect("tempdir");
     let plain = spawn_response_server(
@@ -591,12 +612,33 @@ fn web_discover_business_flow_uses_local_reader_fallback_when_primary_content_is
 
     let dir = tempfile::tempdir().expect("tempdir");
     let server = spawn_reader_fallback_server();
-    std::env::remove_var("TURA_WEB_READER_DISABLED");
-    std::env::set_var(
-        "TURA_WEB_READER_ENDPOINT",
-        format!("http://{}/reader?source=", server.addr),
-    );
-    std::env::set_var("TURA_WEB_READER_MIN_TEXT_CHARS", "200");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_WEB_READER_DISABLED")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var(
+            "TURA_WEB_READER_ENDPOINT",
+            format!("http://{}/reader?source=", server.addr),
+        )
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_READER_MIN_TEXT_CHARS", "200")
+    };
 
     let command_line = format!(
         "web_discover website {} --download-dir reader-pages --max-results 1",
@@ -645,7 +687,14 @@ fn web_discover_business_flow_uses_local_reader_fallback_when_primary_content_is
 fn web_discover_business_flow_records_truncated_response_body_without_hanging_or_public_fallback() {
     let _guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
     let previous_disabled = std::env::var_os("TURA_WEB_READER_DISABLED");
-    std::env::set_var("TURA_WEB_READER_DISABLED", "true");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_READER_DISABLED", "true")
+    };
 
     let dir = tempfile::tempdir().expect("tempdir");
     let server = spawn_truncated_response_server();
@@ -684,7 +733,14 @@ fn web_discover_business_flow_records_truncated_response_body_without_hanging_or
 fn web_discover_business_flow_retries_local_cf_challenge_without_public_reader() {
     let _guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
     let previous_disabled = std::env::var_os("TURA_WEB_READER_DISABLED");
-    std::env::set_var("TURA_WEB_READER_DISABLED", "true");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_READER_DISABLED", "true")
+    };
 
     let dir = tempfile::tempdir().expect("tempdir");
     let server = spawn_cf_retry_page_server();
@@ -733,14 +789,48 @@ fn web_discover_business_flow_falls_back_from_failed_brave_route_to_local_duckdu
     let previous_exa_disabled = std::env::var_os("TURA_EXA_SEARCH_DISABLED");
     let previous_duck_endpoint = std::env::var_os("TURA_DUCKDUCKGO_SEARCH_ENDPOINT");
     let previous_reader_disabled = std::env::var_os("TURA_WEB_READER_DISABLED");
-    std::env::set_var("TURA_BRAVE_SEARCH_API_KEY", "local-business-key");
-    std::env::set_var("TURA_BRAVE_WEB_SEARCH_ENDPOINT", &search.brave_url);
-    std::env::set_var("TURA_EXA_SEARCH_DISABLED", "true");
-    std::env::set_var("TURA_DUCKDUCKGO_SEARCH_ENDPOINT", &search.duckduckgo_url);
-    std::env::set_var("TURA_WEB_READER_DISABLED", "true");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_BRAVE_SEARCH_API_KEY", "local-business-key")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_BRAVE_WEB_SEARCH_ENDPOINT", &search.brave_url)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_EXA_SEARCH_DISABLED", "true")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_DUCKDUCKGO_SEARCH_ENDPOINT", &search.duckduckgo_url)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_READER_DISABLED", "true")
+    };
 
-    let command_line =
-        "web_discover website tura local search fallback --download-dir search-pages --max-results 1";
+    let command_line = "web_discover website tura local search fallback --download-dir search-pages --max-results 1";
     let response = execute(command_line, dir.path(), 10);
 
     restore_env("TURA_BRAVE_SEARCH_API_KEY", previous_brave_key);
@@ -797,8 +887,22 @@ fn web_discover_business_flow_uses_custom_search_endpoint_and_fetches_only_usabl
     let server = spawn_custom_search_with_pages_server();
     let previous_custom = std::env::var_os("TURA_WEB_DISCOVER_ENDPOINT");
     let previous_reader_disabled = std::env::var_os("TURA_WEB_READER_DISABLED");
-    std::env::set_var("TURA_WEB_DISCOVER_ENDPOINT", &server.search_url);
-    std::env::set_var("TURA_WEB_READER_DISABLED", "true");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_DISCOVER_ENDPOINT", &server.search_url)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_READER_DISABLED", "true")
+    };
 
     let command_line =
         "web_discover website custom local endpoint --download-dir custom-pages --max-results 3";

--- a/crates/gateway/src/api/about.rs
+++ b/crates/gateway/src/api/about.rs
@@ -185,21 +185,23 @@ async fn star_repository_with<R: AboutRuntime>(
 ) -> Result<AboutStarResponse, AboutError> {
     let mut attempted = HashSet::new();
     for key in ["GITHUB_TOKEN", "GH_TOKEN", "TURA_GITHUB_TOKEN"] {
-        if let Some(token) = runtime.environment_token(key) {
-            if attempted.insert(token.clone()) && runtime.add_star(&token).await {
-                return Ok(AboutStarResponse {
-                    outcome: AboutStarOutcome::Starred,
-                });
-            }
+        if let Some(token) = runtime.environment_token(key)
+            && attempted.insert(token.clone())
+            && runtime.add_star(&token).await
+        {
+            return Ok(AboutStarResponse {
+                outcome: AboutStarOutcome::Starred,
+            });
         }
     }
     for key in ["github.token", "github.oauth-token", "github.oauthToken"] {
-        if let Some(token) = runtime.git_token(key).await {
-            if attempted.insert(token.clone()) && runtime.add_star(&token).await {
-                return Ok(AboutStarResponse {
-                    outcome: AboutStarOutcome::Starred,
-                });
-            }
+        if let Some(token) = runtime.git_token(key).await
+            && attempted.insert(token.clone())
+            && runtime.add_star(&token).await
+        {
+            return Ok(AboutStarResponse {
+                outcome: AboutStarOutcome::Starred,
+            });
         }
     }
     runtime
@@ -320,12 +322,12 @@ fn package_json_candidates() -> Vec<PathBuf> {
     if let Ok(current) = std::env::current_dir() {
         candidates.push(current.join("package.json"));
     }
-    if let Ok(executable) = std::env::current_exe() {
-        if let Some(parent) = executable.parent() {
-            candidates.push(parent.join("package.json"));
-            if let Some(grandparent) = parent.parent() {
-                candidates.push(grandparent.join("package.json"));
-            }
+    if let Ok(executable) = std::env::current_exe()
+        && let Some(parent) = executable.parent()
+    {
+        candidates.push(parent.join("package.json"));
+        if let Some(grandparent) = parent.parent() {
+            candidates.push(grandparent.join("package.json"));
         }
     }
     candidates

--- a/crates/gateway/src/api/agent.rs
+++ b/crates/gateway/src/api/agent.rs
@@ -249,7 +249,14 @@ mod tests {
         let _guard = AGENT_ENV_LOCK.lock().await;
         let previous_root = std::env::var_os("TURA_PROJECT_ROOT");
         let temp = TempDir::new().expect("temp root");
-        std::env::set_var("TURA_PROJECT_ROOT", temp.path());
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", temp.path())
+        };
 
         let stored = upsert_agent_in_store(
             Some("helper-agent".to_string()),
@@ -287,7 +294,14 @@ mod tests {
         let _guard = AGENT_ENV_LOCK.lock().await;
         let previous_root = std::env::var_os("TURA_PROJECT_ROOT");
         let temp = TempDir::new().expect("temp root");
-        std::env::set_var("TURA_PROJECT_ROOT", temp.path());
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", temp.path())
+        };
 
         let error = upsert_agent_in_store(
             Some("../escape".to_string()),
@@ -357,8 +371,26 @@ mod tests {
 
     fn restore_project_root(previous: Option<std::ffi::OsString>) {
         match previous {
-            Some(value) => std::env::set_var("TURA_PROJECT_ROOT", value),
-            None => std::env::remove_var("TURA_PROJECT_ROOT"),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("TURA_PROJECT_ROOT", value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var("TURA_PROJECT_ROOT")
+                }
+            }
         }
     }
 }

--- a/crates/gateway/src/api/global.rs
+++ b/crates/gateway/src/api/global.rs
@@ -389,7 +389,7 @@ pub async fn session_event(
 fn event_stream(
     state: EventStreamState,
 ) -> impl futures::Stream<Item = Result<SseEvent, Infallible>> {
-    let stream = futures::stream::unfold(state, |mut state| async move {
+    futures::stream::unfold(state, |mut state| async move {
         loop {
             let event = if state.first {
                 state.first = false;
@@ -418,8 +418,7 @@ fn event_stream(
 
             tokio::time::sleep(Duration::from_millis(250)).await;
         }
-    });
-    stream
+    })
 }
 
 fn event_visible_to_frontend(event: &GlobalEvent) -> bool {

--- a/crates/gateway/src/api/path.rs
+++ b/crates/gateway/src/api/path.rs
@@ -34,12 +34,13 @@ fn percent_decode(value: &str) -> String {
     let mut output = Vec::with_capacity(bytes.len());
     let mut index = 0;
     while index < bytes.len() {
-        if bytes[index] == b'%' && index + 2 < bytes.len() {
-            if let (Some(high), Some(low)) = (hex(bytes[index + 1]), hex(bytes[index + 2])) {
-                output.push((high << 4) | low);
-                index += 3;
-                continue;
-            }
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) = (hex(bytes[index + 1]), hex(bytes[index + 2]))
+        {
+            output.push((high << 4) | low);
+            index += 3;
+            continue;
         }
         output.push(bytes[index]);
         index += 1;

--- a/crates/gateway/src/api/product.rs
+++ b/crates/gateway/src/api/product.rs
@@ -205,15 +205,14 @@ impl ProductStore {
         if let Some(workspace_id) = query.workspace_id.clone() {
             return workspace_id;
         }
-        if let Some(slug) = query.workspace_slug.as_deref() {
-            if let Some(workspace) = self
+        if let Some(slug) = query.workspace_slug.as_deref()
+            && let Some(workspace) = self
                 .workspaces
                 .read()
                 .values()
                 .find(|workspace| workspace.slug == slug)
-            {
-                return workspace.id.clone();
-            }
+        {
+            return workspace.id.clone();
         }
         "local".to_string()
     }

--- a/crates/gateway/src/api/project.rs
+++ b/crates/gateway/src/api/project.rs
@@ -316,12 +316,13 @@ fn percent_decode(value: &str) -> String {
     let mut index = 0;
 
     while index < bytes.len() {
-        if bytes[index] == b'%' && index + 2 < bytes.len() {
-            if let (Some(high), Some(low)) = (hex(bytes[index + 1]), hex(bytes[index + 2])) {
-                output.push((high << 4) | low);
-                index += 3;
-                continue;
-            }
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) = (hex(bytes[index + 1]), hex(bytes[index + 2]))
+        {
+            output.push((high << 4) | low);
+            index += 3;
+            continue;
         }
 
         output.push(bytes[index]);

--- a/crates/gateway/src/api/provider.rs
+++ b/crates/gateway/src/api/provider.rs
@@ -406,7 +406,14 @@ fn persist_provider_auth(provider_id: &str, auth: &ProviderAuth) -> io::Result<(
         .map(|value| value.trim().to_string())
         .unwrap_or_else(|| provider_env_key(provider_id));
     upsert_env_value(&env_path, &api_key, key)?;
-    std::env::set_var(&api_key, key);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var(&api_key, key)
+    };
 
     let requested_login = auth
         .metadata
@@ -419,7 +426,14 @@ fn persist_provider_auth(provider_id: &str, auth: &ProviderAuth) -> io::Result<(
     if auth.auth_type == "api" || requested_login == "api" {
         let login_key = provider_login_key(provider_id);
         upsert_env_value(&env_path, &login_key, "api")?;
-        std::env::set_var(&login_key, "api");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(&login_key, "api")
+        };
 
         upsert_provider_auth_config(provider_id, "api", Some(&login_key), auth, None)?;
     }
@@ -428,7 +442,14 @@ fn persist_provider_auth(provider_id: &str, auth: &ProviderAuth) -> io::Result<(
         let login = requested_login.as_str();
         let login_key = provider_login_key(provider_id);
         upsert_env_value(&env_path, &login_key, login)?;
-        std::env::set_var(&login_key, login);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(&login_key, login)
+        };
 
         if let Some(registry_entry) = tura_llm_rust::provider_auth_registry_entry(provider_id) {
             if let (Some(refresh_key), Some(refresh)) = (
@@ -438,12 +459,26 @@ fn persist_provider_auth(provider_id: &str, auth: &ProviderAuth) -> io::Result<(
                     .filter(|value| !value.trim().is_empty()),
             ) {
                 upsert_env_value(&env_path, refresh_key, refresh)?;
-                std::env::set_var(refresh_key, refresh);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(refresh_key, refresh)
+                };
             }
             if let (Some(expires_key), Some(expires)) = (registry_entry.expires_env, auth.expires) {
                 let expires_value = expires.to_string();
                 upsert_env_value(&env_path, expires_key, &expires_value)?;
-                std::env::set_var(expires_key, expires_value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(expires_key, expires_value)
+                };
             }
             if let (Some(account_key), Some(account_id)) = (
                 registry_entry.account_env,
@@ -452,7 +487,14 @@ fn persist_provider_auth(provider_id: &str, auth: &ProviderAuth) -> io::Result<(
                     .filter(|value| !value.trim().is_empty()),
             ) {
                 upsert_env_value(&env_path, account_key, account_id)?;
-                std::env::set_var(account_key, account_id);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(account_key, account_id)
+                };
             }
         }
 
@@ -728,15 +770,27 @@ fn logout_provider_auth(provider_id: &str) -> io::Result<()> {
         _ => true,
     };
 
-    if should_clear_shared_token {
-        if let Some(token_env) = status.token_env.as_deref() {
-            upsert_env_value(&env_path, token_env, "")?;
-            std::env::remove_var(token_env);
-        }
+    if should_clear_shared_token && let Some(token_env) = status.token_env.as_deref() {
+        upsert_env_value(&env_path, token_env, "")?;
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(token_env)
+        };
     }
     if let Some(login_env) = status.login_env.as_deref() {
         upsert_env_value(&env_path, login_env, "")?;
-        std::env::remove_var(login_env);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(login_env)
+        };
     }
     for key in [
         status.refresh_env.as_deref(),
@@ -748,7 +802,14 @@ fn logout_provider_auth(provider_id: &str) -> io::Result<()> {
     .flatten()
     {
         upsert_env_value(&env_path, key, "")?;
-        std::env::remove_var(key);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(key)
+        };
     }
 
     update_provider_auth_config_status(provider_id, "revoked")

--- a/crates/gateway/src/api/provider/catalog.rs
+++ b/crates/gateway/src/api/provider/catalog.rs
@@ -18,10 +18,10 @@ pub async fn list_providers() -> Json<ProviderListResponse> {
 
 pub async fn list_providers_value() -> ProviderListResponse {
     let settings = tura_llm_rust::Settings::default().await.ok();
-    if let Some(settings) = settings.as_deref() {
-        if let Some(route) = active_agent_route(settings) {
-            return provider_list_for_route(settings, route);
-        }
+    if let Some(settings) = settings.as_deref()
+        && let Some(route) = active_agent_route(settings)
+    {
+        return provider_list_for_route(settings, route);
     }
 
     let providers = global_store().list_providers();
@@ -379,10 +379,9 @@ pub(super) fn provider_env_from_settings(
         .token_env
         .as_deref()
         .filter(|value| !value.trim().is_empty())
+        && !env.iter().any(|item| item == token_env)
     {
-        if !env.iter().any(|item| item == token_env) {
-            env.insert(0, token_env.to_string());
-        }
+        env.insert(0, token_env.to_string());
     }
     env
 }

--- a/crates/gateway/src/api/provider/config.rs
+++ b/crates/gateway/src/api/provider/config.rs
@@ -138,13 +138,27 @@ mod tests {
     impl EnvRestore {
         fn remove(key: &'static str) -> Self {
             let previous = std::env::var_os(key);
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
             Self { key, previous }
         }
 
         fn set(key: &'static str, value: &std::ffi::OsStr) -> Self {
             let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
             Self { key, previous }
         }
     }
@@ -152,8 +166,26 @@ mod tests {
     impl Drop for EnvRestore {
         fn drop(&mut self) {
             match self.previous.as_ref() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(self.key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(self.key)
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/src/api/provider/oauth_flow.rs
+++ b/crates/gateway/src/api/provider/oauth_flow.rs
@@ -144,7 +144,9 @@ pub async fn oauth_authorize_value(
         (
             url,
             OAuthMethod::Code,
-            format!("Open the login page, copy your browser token, and paste it here. Confirmation: {code}"),
+            format!(
+                "Open the login page, copy your browser token, and paste it here. Confirmation: {code}"
+            ),
         )
     } else if selected_method.kind == AuthMethodKind::OAuthPkce {
         (
@@ -315,17 +317,16 @@ async fn complete_oauth_callback(
         }
         return response;
     }
-    if pending.method == "oauth_pkce" {
-        if let Some(state) = normalized_code.state.as_deref() {
-            if pending.state.as_deref() != Some(state) {
-                return oauth_callback_response(
+    if pending.method == "oauth_pkce"
+        && let Some(state) = normalized_code.state.as_deref()
+        && pending.state.as_deref() != Some(state)
+    {
+        return oauth_callback_response(
                     &provider_id,
                     false,
                     "provider.oauth.state_mismatch",
                     "OAuth state does not match the pending authorization request. Start login again and paste the newest code.",
                 );
-            }
-        }
     }
     let tokens = if matches!(pending.method.as_str(), "oauth_pkce" | "device_code") {
         match exchange_oauth_code(&provider_id, &normalized_code, &pending).await {
@@ -447,26 +448,25 @@ fn normalize_oauth_code(code: &str) -> NormalizedOAuthCode {
             verifier: None,
         };
     }
-    if let Ok(url) = reqwest::Url::parse(trimmed) {
-        if let Some(code) = url
+    if let Ok(url) = reqwest::Url::parse(trimmed)
+        && let Some(code) = url
             .query_pairs()
             .find_map(|(key, value)| (key == "code").then(|| value.to_string()))
-        {
-            let state = url
-                .query_pairs()
-                .find_map(|(key, value)| (key == "state").then(|| value.to_string()))
-                .or_else(|| {
-                    url.fragment()
-                        .map(str::trim)
-                        .filter(|value| !value.is_empty())
-                        .map(ToString::to_string)
-                });
-            return NormalizedOAuthCode {
-                code: code.trim().to_string(),
-                state,
-                verifier: None,
-            };
-        }
+    {
+        let state = url
+            .query_pairs()
+            .find_map(|(key, value)| (key == "state").then(|| value.to_string()))
+            .or_else(|| {
+                url.fragment()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToString::to_string)
+            });
+        return NormalizedOAuthCode {
+            code: code.trim().to_string(),
+            state,
+            verifier: None,
+        };
     }
     let mut parts = trimmed.splitn(2, '#');
     let code = parts.next().unwrap_or_default().trim().to_string();
@@ -677,7 +677,7 @@ async fn finish_oauth_redirect_callback(
             return Html(oauth_callback_html(
                 false,
                 &format!("Token exchange failed: {error}"),
-            ))
+            ));
         }
     };
     let auth = auth_update::oauth_auth(

--- a/crates/gateway/src/api/provider/tests.rs
+++ b/crates/gateway/src/api/provider/tests.rs
@@ -212,7 +212,14 @@ async fn google_oauth_support_prefers_provider_specific_env_then_google_default(
         "GEMINI_OAUTH_REDIRECT_URI",
         "GEMINI_OAUTH_SCOPE",
     ] {
-        std::env::remove_var(key);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(key)
+        };
     }
 
     set_env("GOOGLE_OAUTH_CLIENT_ID", "google-client");
@@ -264,7 +271,14 @@ async fn google_oauth_support_prefers_provider_specific_env_then_google_default(
         "GEMINI_OAUTH_REDIRECT_URI",
         "GEMINI_OAUTH_SCOPE",
     ] {
-        std::env::remove_var(key);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(key)
+        };
     }
 }
 
@@ -426,7 +440,14 @@ async fn catalog_enrich_provider_list_prefers_env_then_api_then_config() {
     assert!(connected.iter().any(|id| id == "test-provider"));
     assert!(!connected.iter().any(|id| id == "config-provider"));
 
-    std::env::remove_var("TURA_GATEWAY_TEST_PROVIDER_KEY");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_GATEWAY_TEST_PROVIDER_KEY")
+    };
 }
 
 #[test]
@@ -711,7 +732,14 @@ async fn provider_list_hides_claude_models_from_picker_catalog() {
 #[tokio::test]
 async fn provider_list_masks_configured_key_value() {
     let _guard = ENV_LOCK.lock().await;
-    std::env::set_var("LINE_CHANNEL_ACCESS_TOKEN", "line-test-token");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LINE_CHANNEL_ACCESS_TOKEN", "line-test-token")
+    };
 
     let settings = tura_llm_rust::Settings::default()
         .await
@@ -727,7 +755,14 @@ async fn provider_list_masks_configured_key_value() {
         .expect("LINE service provider should be listed");
     assert_eq!(line.key.as_deref(), Some("line*******oken"));
 
-    std::env::remove_var("LINE_CHANNEL_ACCESS_TOKEN");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("LINE_CHANNEL_ACCESS_TOKEN")
+    };
 }
 
 #[test]
@@ -779,8 +814,22 @@ async fn provider_auth_save_preserves_config_token_env_for_validation() {
         "TURA_PROVIDER_CONFIG",
         config_path.to_string_lossy().as_ref(),
     );
-    std::env::remove_var("CUSTOM_PROVIDER_KEY");
-    std::env::remove_var("CUSTOM-OPENAI_API_KEY");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("CUSTOM_PROVIDER_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("CUSTOM-OPENAI_API_KEY")
+    };
 
     let auth = ProviderAuth {
         auth_type: "api".to_string(),
@@ -808,10 +857,38 @@ async fn provider_auth_save_preserves_config_token_env_for_validation() {
     assert!(status.configured);
     assert!(status.authenticated);
 
-    std::env::remove_var("CUSTOM_PROVIDER_KEY");
-    std::env::remove_var("CUSTOM-OPENAI_API_KEY");
-    std::env::remove_var("TURA_ENV_PATH");
-    std::env::remove_var("TURA_PROVIDER_CONFIG");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("CUSTOM_PROVIDER_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("CUSTOM-OPENAI_API_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_ENV_PATH")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_PROVIDER_CONFIG")
+    };
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
 
@@ -1424,10 +1501,24 @@ fn clear_openai_refresh_test_env() {
         "CLAUDE_CODE_REFRESH_TOKEN",
         "CLAUDE_CODE_TOKEN_EXPIRES",
     ] {
-        std::env::remove_var(key);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(key)
+        };
     }
 }
 
 fn set_env(key: &str, value: &str) {
-    std::env::set_var(key, value);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var(key, value)
+    };
 }

--- a/crates/gateway/src/api/session.rs
+++ b/crates/gateway/src/api/session.rs
@@ -165,21 +165,20 @@ fn filter_list_sessions(
     sessions
         .into_iter()
         .filter(|session| {
-            if let Some(directory_key) = &directory_key {
-                if workspace_key(session.directory.as_deref().unwrap_or_default()) != *directory_key
-                {
-                    return false;
-                }
+            if let Some(directory_key) = &directory_key
+                && workspace_key(session.directory.as_deref().unwrap_or_default()) != *directory_key
+            {
+                return false;
             }
             if (params.roots == Some(true) || !params.include_children)
                 && session.parent_id.is_some()
             {
                 return false;
             }
-            if let Some(start) = params.start {
-                if session.updated_at < start {
-                    return false;
-                }
+            if let Some(start) = params.start
+                && session.updated_at < start
+            {
+                return false;
             }
             if let Some(search) = &search {
                 let title = session
@@ -407,12 +406,13 @@ fn percent_decode(value: &str) -> String {
     let mut output = Vec::with_capacity(bytes.len());
     let mut index = 0;
     while index < bytes.len() {
-        if bytes[index] == b'%' && index + 2 < bytes.len() {
-            if let (Some(high), Some(low)) = (hex(bytes[index + 1]), hex(bytes[index + 2])) {
-                output.push((high << 4) | low);
-                index += 3;
-                continue;
-            }
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) = (hex(bytes[index + 1]), hex(bytes[index + 2]))
+        {
+            output.push((high << 4) | low);
+            index += 3;
+            continue;
         }
         output.push(bytes[index]);
         index += 1;

--- a/crates/gateway/src/api/session_log.rs
+++ b/crates/gateway/src/api/session_log.rs
@@ -110,12 +110,13 @@ fn percent_decode(value: &str) -> String {
     let mut output = Vec::with_capacity(bytes.len());
     let mut index = 0;
     while index < bytes.len() {
-        if bytes[index] == b'%' && index + 2 < bytes.len() {
-            if let (Some(high), Some(low)) = (hex(bytes[index + 1]), hex(bytes[index + 2])) {
-                output.push((high << 4) | low);
-                index += 3;
-                continue;
-            }
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) = (hex(bytes[index + 1]), hex(bytes[index + 2]))
+        {
+            output.push((high << 4) | low);
+            index += 3;
+            continue;
         }
         output.push(bytes[index]);
         index += 1;

--- a/crates/gateway/src/api/session_prompt.rs
+++ b/crates/gateway/src/api/session_prompt.rs
@@ -369,18 +369,16 @@ fn prompt_payload_with_frontend_ids(
     if let Some(parts) = object
         .get_mut("parts")
         .and_then(serde_json::Value::as_array_mut)
-    {
-        if let Some(part) = parts.iter_mut().find(|part| {
+        && let Some(part) = parts.iter_mut().find(|part| {
             part.get("type")
                 .and_then(serde_json::Value::as_str)
                 .is_none_or(|part_type| part_type == "text")
-        }) {
-            if let Some(part_object) = part.as_object_mut() {
-                part_object
-                    .entry("id".to_string())
-                    .or_insert_with(|| serde_json::Value::String(part_id));
-            }
-        }
+        })
+        && let Some(part_object) = part.as_object_mut()
+    {
+        part_object
+            .entry("id".to_string())
+            .or_insert_with(|| serde_json::Value::String(part_id));
     }
     payload
 }
@@ -830,12 +828,11 @@ fn config_keys(content: &str) -> std::collections::BTreeSet<String> {
 }
 
 fn explicit_config_model_override(config: &PromptSessionConfig) -> Option<String> {
-    if config.has("model") {
-        if let Some(model) =
+    if config.has("model")
+        && let Some(model) =
             non_empty_string(config.config.model.clone()).filter(|model| model.contains('/'))
-        {
-            return Some(model);
-        }
+    {
+        return Some(model);
     }
     if !(config.has("active_provider") || config.has("active_model")) {
         return None;

--- a/crates/gateway/src/bin/gateway.rs
+++ b/crates/gateway/src/bin/gateway.rs
@@ -29,7 +29,14 @@ fn main() {
         .filter(|value| !value.trim().is_empty())
         .is_none()
     {
-        std::env::set_var("OPENAI_LOGIN", "oauth");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("OPENAI_LOGIN", "oauth")
+        };
     }
 
     let desired_port = desired_port_for_exe();
@@ -42,7 +49,9 @@ fn main() {
             return;
         }
         PortDecision::Unavailable(port) => {
-            eprintln!("gateway port {port} is occupied by a foreign process; set PORT to an explicit free port or stop the foreign process");
+            eprintln!(
+                "gateway port {port} is occupied by a foreign process; set PORT to an explicit free port or stop the foreign process"
+            );
             std::process::exit(1);
         }
     };
@@ -65,8 +74,22 @@ fn main() {
         }
     };
     // Keep the resolved port visible to children (runtime workers, callbacks).
-    std::env::set_var("PORT", port.to_string());
-    std::env::set_var(tura_path::TURA_GATEWAY_PORT_ENV, port.to_string());
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("PORT", port.to_string())
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var(tura_path::TURA_GATEWAY_PORT_ENV, port.to_string())
+    };
 
     if let Err(error) = gateway::router_process::start_global_router_process() {
         eprintln!("gateway failed to start persistent router: {error:#}");
@@ -319,20 +342,41 @@ fn gateway_identity_on_port(port: u16) -> Option<GatewayIdentity> {
 fn configure_release_runtime_env() {
     let root = project_root_from_exe();
     if std::env::var_os("TURA_PROJECT_ROOT").is_none() {
-        std::env::set_var("TURA_PROJECT_ROOT", &root);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", &root)
+        };
     }
     if std::env::var_os("TURA_PROVIDER_CONFIG").is_none() {
         let provider_config = PathBuf::from(&root)
             .join("config")
             .join("provider_config.json");
         if provider_config.exists() {
-            std::env::set_var("TURA_PROVIDER_CONFIG", provider_config);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_PROVIDER_CONFIG", provider_config)
+            };
         }
     }
     if std::env::var_os("TURA_ENV_PATH").is_none() {
         let env_path = PathBuf::from(&root).join(".env");
         if env_path.exists() {
-            std::env::set_var("TURA_ENV_PATH", env_path);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_ENV_PATH", env_path)
+            };
         }
     }
 }
@@ -677,9 +721,23 @@ mod tests {
                 .collect::<Vec<_>>();
             for (key, value) in values {
                 if value.is_empty() {
-                    std::env::remove_var(key);
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    };
                 } else {
-                    std::env::set_var(key, value);
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    };
                 }
             }
             Self { previous }
@@ -690,9 +748,23 @@ mod tests {
         fn drop(&mut self) {
             for (key, value) in self.previous.drain(..).rev() {
                 if let Some(value) = value {
-                    std::env::set_var(key, value);
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    };
                 } else {
-                    std::env::remove_var(key);
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    };
                 }
             }
         }

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::unwrap_used)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 pub mod api;
 pub mod channel;
@@ -52,8 +52,26 @@ pub(crate) mod test_support {
         fn drop(&mut self) {
             for (key, value) in &self.keys {
                 match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    Some(value) => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::set_var(key, value)
+                        }
+                    }
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    None => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::remove_var(key)
+                        }
+                    }
                 }
             }
         }
@@ -73,9 +91,30 @@ pub(crate) mod test_support {
             let root = tempfile::tempdir().expect("session db root");
             let home = root.path().join("home");
             std::fs::create_dir_all(&home).expect("session db home");
-            std::env::set_var("TURA_HOME", &home);
-            std::env::set_var("SESSION_LOG_DB_ROOT", root.path());
-            std::env::remove_var("TURA_DB_ROOT");
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_HOME", &home)
+            };
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("SESSION_LOG_DB_ROOT", root.path())
+            };
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("TURA_DB_ROOT")
+            };
 
             let handle = std::thread::spawn(session_log::service::run_socket_service);
             let started = std::time::Instant::now();

--- a/crates/gateway/src/router_process.rs
+++ b/crates/gateway/src/router_process.rs
@@ -300,11 +300,15 @@ impl RouterProcess {
         self.ensure_started()?;
         let response = match self.call_once(method, payload.clone()) {
             Ok(response) => response,
-            Err(first_error) => {
+            Err(first_error) if router_call_is_replay_safe(method) => {
                 *self.last_error.lock() = Some(first_error.to_string());
                 *self.addr.lock() = None;
                 self.ensure_started()?;
                 self.call_once(method, payload)?
+            }
+            Err(error) => {
+                *self.last_error.lock() = Some(error.to_string());
+                return Err(error);
             }
         };
 
@@ -360,7 +364,7 @@ impl RouterProcess {
     }
 
     fn call_once(&self, method: &str, payload: serde_json::Value) -> Result<serde_json::Value> {
-        self.call_once_with_timeout(method, payload, read_timeout_for(method))
+        self.call_once_with_read_timeout(method, payload, read_timeout_for(method))
     }
 
     fn call_once_with_timeout(
@@ -368,6 +372,15 @@ impl RouterProcess {
         method: &str,
         payload: serde_json::Value,
         timeout: Duration,
+    ) -> Result<serde_json::Value> {
+        self.call_once_with_read_timeout(method, payload, Some(timeout))
+    }
+
+    fn call_once_with_read_timeout(
+        &self,
+        method: &str,
+        payload: serde_json::Value,
+        timeout: Option<Duration>,
     ) -> Result<serde_json::Value> {
         let addr = self
             .addr
@@ -496,14 +509,14 @@ impl RouterProcess {
 fn call_router_addr(
     addr: &str,
     request: &IpcRequest,
-    timeout: Duration,
+    timeout: Option<Duration>,
 ) -> Result<serde_json::Value> {
     let socket: SocketAddr = addr
         .parse()
         .with_context(|| format!("invalid router daemon address {addr:?}"))?;
     let stream = TcpStream::connect_timeout(&socket, Duration::from_secs(2))
         .with_context(|| format!("failed to connect to router daemon at {addr}"))?;
-    stream.set_read_timeout(Some(timeout))?;
+    stream.set_read_timeout(timeout)?;
     stream.set_write_timeout(Some(Duration::from_secs(10)))?;
     let mut writer = stream.try_clone()?;
     writer.write_all(format!("{}\n", serde_json::to_string(request)?).as_bytes())?;
@@ -526,25 +539,36 @@ fn call_router_addr(
     }
 }
 
-fn read_timeout_for(method: &str) -> Duration {
+fn read_timeout_for(method: &str) -> Option<Duration> {
     if method == "health_check" {
-        ROUTER_HEALTH_TIMEOUT
+        Some(ROUTER_HEALTH_TIMEOUT)
     } else if method == "execution.probe_sessions" {
-        Duration::from_secs(5)
+        Some(Duration::from_secs(5))
     } else if method == "execution.shutdown" {
-        Duration::from_secs(10)
+        Some(Duration::from_secs(10))
+    } else if method == router_contract::METHOD_ENQUEUE_TURN {
+        // A turn may legitimately outlive the ordinary router request budget.
+        // Keep the socket attached to that one execution unless an operator
+        // explicitly configures a deadline.
+        router_execution_timeout_override()
     } else {
-        router_execution_timeout()
+        Some(router_execution_timeout_override().unwrap_or(DEFAULT_ROUTER_EXECUTION_TIMEOUT))
     }
 }
 
-fn router_execution_timeout() -> Duration {
+fn router_execution_timeout_override() -> Option<Duration> {
     std::env::var("TURA_ROUTER_EXECUTION_TIMEOUT_SECS")
         .ok()
         .and_then(|value| value.trim().parse::<u64>().ok())
         .filter(|seconds| *seconds > 0)
         .map(Duration::from_secs)
-        .unwrap_or(DEFAULT_ROUTER_EXECUTION_TIMEOUT)
+}
+
+fn router_call_is_replay_safe(method: &str) -> bool {
+    // Once enqueue_turn has been written, a transport error cannot tell us
+    // whether the router accepted it. Replaying the same runtime_id can race
+    // its now-terminal lease and must not happen implicitly.
+    method != router_contract::METHOD_ENQUEUE_TURN
 }
 
 fn router_addr_path() -> PathBuf {
@@ -1024,26 +1048,35 @@ mod tests {
     }
 
     #[test]
-    fn router_execution_timeout_defaults_to_long_prompt_budget_and_allows_override() {
+    fn router_enqueue_has_no_default_deadline_and_allows_explicit_override() {
         let _guard = crate::test_support::env_lock();
         {
             let _env = EnvGuard::set("TURA_ROUTER_EXECUTION_TIMEOUT_SECS", None);
+            assert_eq!(read_timeout_for("execution.enqueue_turn"), None);
             assert_eq!(
-                read_timeout_for("execution.enqueue_turn"),
-                Duration::from_secs(35 * 60)
+                read_timeout_for("health_check"),
+                Some(ROUTER_HEALTH_TIMEOUT)
             );
-            assert_eq!(read_timeout_for("health_check"), ROUTER_HEALTH_TIMEOUT);
             assert_eq!(
                 read_timeout_for("execution.shutdown"),
-                Duration::from_secs(10)
+                Some(Duration::from_secs(10))
             );
         }
 
         let _env = EnvGuard::set("TURA_ROUTER_EXECUTION_TIMEOUT_SECS", Some("42"));
         assert_eq!(
             read_timeout_for("execution.enqueue_turn"),
-            Duration::from_secs(42)
+            Some(Duration::from_secs(42))
         );
+    }
+
+    #[test]
+    fn router_enqueue_transport_failure_is_not_replayed() {
+        assert!(!router_call_is_replay_safe(
+            router_contract::METHOD_ENQUEUE_TURN
+        ));
+        assert!(router_call_is_replay_safe("health_check"));
+        assert!(router_call_is_replay_safe("registry.tools.list"));
     }
 
     #[test]
@@ -1398,7 +1431,7 @@ mod tests {
         let response = call_router_addr(
             &success_addr,
             &IpcRequest::health_check("health-test", 2_000),
-            Duration::from_secs(2),
+            Some(Duration::from_secs(2)),
         )?;
         assert_eq!(response["ok"], true);
         assert_eq!(response["payload"]["healthy"], true);
@@ -1427,13 +1460,64 @@ mod tests {
         let response = call_router_addr(
             &error_addr,
             &IpcRequest::call("error-test", "execution.enqueue_turn", json!({})),
-            Duration::from_secs(2),
+            Some(Duration::from_secs(2)),
         )?;
         assert_eq!(response["ok"], false);
         assert_eq!(response["error"], "worker unavailable");
         error_server
             .join()
             .map_err(|_| anyhow!("error router server panicked"))??;
+        Ok(())
+    }
+
+    #[test]
+    fn router_socket_deadline_reproduces_slow_enqueue_failure_but_no_deadline_waits(
+    ) -> anyhow::Result<()> {
+        fn delayed_response(
+            delay: Duration,
+        ) -> anyhow::Result<(String, thread::JoinHandle<anyhow::Result<()>>)> {
+            let listener = TcpListener::bind(("127.0.0.1", 0))?;
+            let addr = listener.local_addr()?.to_string();
+            let server = thread::spawn(move || -> anyhow::Result<()> {
+                let (mut stream, _) = listener.accept()?;
+                let mut request_line = String::new();
+                std::io::BufRead::read_line(
+                    &mut BufReader::new(stream.try_clone()?),
+                    &mut request_line,
+                )?;
+                let request: serde_json::Value = serde_json::from_str(request_line.trim())?;
+                assert_eq!(request["method"], "execution.enqueue_turn");
+                thread::sleep(delay);
+                let response =
+                    serde_json::to_string(&IpcResponse::ok("slow-turn", json!({"done": true})))?;
+                let _ = std::io::Write::write_all(&mut stream, response.as_bytes());
+                let _ = std::io::Write::write_all(&mut stream, b"\n");
+                let _ = std::io::Write::flush(&mut stream);
+                Ok(())
+            });
+            Ok((addr, server))
+        }
+
+        let request =
+            IpcRequest::call("slow-turn", router_contract::METHOD_ENQUEUE_TURN, json!({}));
+
+        let (timed_addr, timed_server) = delayed_response(Duration::from_millis(120))?;
+        let timed_result = call_router_addr(&timed_addr, &request, Some(Duration::from_millis(15)));
+        assert!(
+            timed_result.is_err(),
+            "the former fixed deadline should reproduce the premature read failure"
+        );
+        timed_server
+            .join()
+            .map_err(|_| anyhow!("timed router server panicked"))??;
+
+        let (waiting_addr, waiting_server) = delayed_response(Duration::from_millis(40))?;
+        let response = call_router_addr(&waiting_addr, &request, None)?;
+        assert_eq!(response["ok"], true);
+        assert_eq!(response["payload"]["done"], true);
+        waiting_server
+            .join()
+            .map_err(|_| anyhow!("waiting router server panicked"))??;
         Ok(())
     }
 

--- a/crates/gateway/src/router_process.rs
+++ b/crates/gateway/src/router_process.rs
@@ -4,10 +4,10 @@
 //! as a direct child; router then owns session_db, runtime workers, and
 //! command-run children below that tree.
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex as ParkingMutex;
-use router_contract::{IpcRequest, IpcResponse, METHOD_HEALTH_CHECK, RouterEndpoint};
+use router_contract::{IpcRequest, IpcResponse, RouterEndpoint, METHOD_HEALTH_CHECK};
 use serde_json::json;
 use std::{
     io::{BufRead, BufReader, Write},
@@ -15,8 +15,8 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{
-        Arc,
         atomic::{AtomicU64, Ordering},
+        Arc,
     },
     time::{Duration, Instant},
 };
@@ -1271,11 +1271,11 @@ mod tests {
         assert_eq!(parsed.pid, Some(12));
         assert_eq!(parsed.process_start_time, Some(34));
 
-        assert!(
-            parse_router_endpoint(&json!({"addr": "127.0.0.1:12", "version": "old"}).to_string())
-                .expect("incompatible endpoint should parse")
-                .is_none()
-        );
+        assert!(parse_router_endpoint(
+            &json!({"addr": "127.0.0.1:12", "version": "old"}).to_string()
+        )
+        .expect("incompatible endpoint should parse")
+        .is_none());
         let missing_addr =
             parse_router_endpoint(&json!({"version": tura_path::instance_version()}).to_string())
                 .expect_err("missing address should be rejected");
@@ -1324,10 +1324,8 @@ mod tests {
             process_start_time: None,
         };
         assert!(!router_endpoint_process_identity_matches(&no_start_time));
-        assert!(
-            !terminate_router_endpoint_process(&no_start_time)
-                .expect("missing fingerprint should refuse forced termination")
-        );
+        assert!(!terminate_router_endpoint_process(&no_start_time)
+            .expect("missing fingerprint should refuse forced termination"));
     }
 
     #[test]
@@ -1473,8 +1471,8 @@ mod tests {
     }
 
     #[test]
-    fn router_socket_deadline_reproduces_slow_enqueue_failure_but_no_deadline_waits()
-    -> anyhow::Result<()> {
+    fn router_socket_deadline_reproduces_slow_enqueue_failure_but_no_deadline_waits(
+    ) -> anyhow::Result<()> {
         fn delayed_response(
             delay: Duration,
         ) -> anyhow::Result<(String, thread::JoinHandle<anyhow::Result<()>>)> {

--- a/crates/gateway/src/router_process.rs
+++ b/crates/gateway/src/router_process.rs
@@ -586,7 +586,7 @@ fn read_router_endpoint_record() -> Result<Option<RouterEndpoint>> {
         Ok(raw) => raw,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
-            return Err(error).with_context(|| format!("failed to read {}", path.display()))
+            return Err(error).with_context(|| format!("failed to read {}", path.display()));
         }
     };
     let endpoint = match parse_router_endpoint(raw.trim()) {
@@ -878,15 +878,14 @@ fn router_executable_candidates(root: &Path) -> Vec<PathBuf> {
         "tura_router"
     };
     let mut candidates = Vec::new();
-    if let Ok(current_exe) = std::env::current_exe() {
-        if current_exe
+    if let Ok(current_exe) = std::env::current_exe()
+        && current_exe
             .parent()
             .and_then(Path::file_name)
             .and_then(|name| name.to_str())
             != Some("deps")
-        {
-            candidates.push(current_exe.with_file_name(executable));
-        }
+    {
+        candidates.push(current_exe.with_file_name(executable));
     }
     let profile = if tura_path::build_kind() == "release" {
         "release"
@@ -920,17 +919,56 @@ mod tests {
                 .iter()
                 .map(|key| (*key, std::env::var_os(key)))
                 .collect::<Vec<_>>();
-            std::env::set_var("TURA_HOME", home);
-            std::env::remove_var("SESSION_LOG_DB_ROOT");
-            std::env::remove_var("TURA_DB_ROOT");
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_HOME", home)
+            };
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("SESSION_LOG_DB_ROOT")
+            };
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("TURA_DB_ROOT")
+            };
             Self { previous }
         }
 
         fn set(key: &'static str, value: Option<&str>) -> Self {
             let previous = vec![(key, std::env::var_os(key))];
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
             Self { previous }
         }
@@ -940,8 +978,26 @@ mod tests {
         fn drop(&mut self) {
             for (key, value) in self.previous.drain(..) {
                 match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    Some(value) => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::set_var(key, value)
+                        }
+                    }
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    None => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::remove_var(key)
+                        }
+                    }
                 }
             }
         }

--- a/crates/gateway/src/router_process.rs
+++ b/crates/gateway/src/router_process.rs
@@ -4,10 +4,10 @@
 //! as a direct child; router then owns session_db, runtime workers, and
 //! command-run children below that tree.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex as ParkingMutex;
-use router_contract::{IpcRequest, IpcResponse, RouterEndpoint, METHOD_HEALTH_CHECK};
+use router_contract::{IpcRequest, IpcResponse, METHOD_HEALTH_CHECK, RouterEndpoint};
 use serde_json::json;
 use std::{
     io::{BufRead, BufReader, Write},
@@ -15,8 +15,8 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -1271,11 +1271,11 @@ mod tests {
         assert_eq!(parsed.pid, Some(12));
         assert_eq!(parsed.process_start_time, Some(34));
 
-        assert!(parse_router_endpoint(
-            &json!({"addr": "127.0.0.1:12", "version": "old"}).to_string()
-        )
-        .expect("incompatible endpoint should parse")
-        .is_none());
+        assert!(
+            parse_router_endpoint(&json!({"addr": "127.0.0.1:12", "version": "old"}).to_string())
+                .expect("incompatible endpoint should parse")
+                .is_none()
+        );
         let missing_addr =
             parse_router_endpoint(&json!({"version": tura_path::instance_version()}).to_string())
                 .expect_err("missing address should be rejected");
@@ -1324,8 +1324,10 @@ mod tests {
             process_start_time: None,
         };
         assert!(!router_endpoint_process_identity_matches(&no_start_time));
-        assert!(!terminate_router_endpoint_process(&no_start_time)
-            .expect("missing fingerprint should refuse forced termination"));
+        assert!(
+            !terminate_router_endpoint_process(&no_start_time)
+                .expect("missing fingerprint should refuse forced termination")
+        );
     }
 
     #[test]
@@ -1471,8 +1473,8 @@ mod tests {
     }
 
     #[test]
-    fn router_socket_deadline_reproduces_slow_enqueue_failure_but_no_deadline_waits(
-    ) -> anyhow::Result<()> {
+    fn router_socket_deadline_reproduces_slow_enqueue_failure_but_no_deadline_waits()
+    -> anyhow::Result<()> {
         fn delayed_response(
             delay: Duration,
         ) -> anyhow::Result<(String, thread::JoinHandle<anyhow::Result<()>>)> {

--- a/crates/gateway/src/session/store.rs
+++ b/crates/gateway/src/session/store.rs
@@ -300,14 +300,12 @@ impl SessionStore {
         let session_id = projection.session_id.clone();
         let parent_id = projection.parent_id.clone();
         let mut sessions = self.sessions.write();
-        if only_if_absent {
-            if let Some(current) = sessions.get(&session_id) {
-                return ProjectionCacheWrite {
-                    session: api_session_from_info(current, current.projection.parent_id.clone()),
-                    changed: false,
-                    inserted: false,
-                };
-            }
+        if only_if_absent && let Some(current) = sessions.get(&session_id) {
+            return ProjectionCacheWrite {
+                session: api_session_from_info(current, current.projection.parent_id.clone()),
+                changed: false,
+                inserted: false,
+            };
         }
         let previous = sessions
             .get(&session_id)

--- a/crates/gateway/src/session/store_frontend.rs
+++ b/crates/gateway/src/session/store_frontend.rs
@@ -110,10 +110,10 @@ pub(crate) fn normalize_command_run_frontend_state(
     metadata: Option<&serde_json::Value>,
 ) {
     let results_snapshot = command_run_frontend_results_snapshot(state, metadata);
-    if let Some(object) = state.as_object_mut() {
-        if let Some(results) = results_snapshot {
-            upsert_streamed_command_run_results(object, results);
-        }
+    if let Some(object) = state.as_object_mut()
+        && let Some(results) = results_snapshot
+    {
+        upsert_streamed_command_run_results(object, results);
     }
     let commands = command_run_frontend_commands(state, metadata);
     if let Some(object) = state.as_object_mut() {

--- a/crates/gateway/src/session_log_writer.rs
+++ b/crates/gateway/src/session_log_writer.rs
@@ -16,7 +16,7 @@ pub fn write_session_log(command: SessionLogCommand) -> Result<()> {
             Ok(response) => {
                 return Err(anyhow!(
                     "unexpected session_log write response: {response:?}"
-                ))
+                ));
             }
             Err(error) => {
                 tracing::warn!(error = %error, "session_log IPC write failed; enqueueing write");

--- a/crates/gateway/src/tray.rs
+++ b/crates/gateway/src/tray.rs
@@ -318,10 +318,10 @@ fn update_menu_items(handle: &mut TrayMenuHandle, model: Vec<TrayMenuEntry>) {
         let Some(item) = item else {
             continue;
         };
-        if old.label != new.label {
-            if let Some(label) = new.label.as_deref() {
-                item.set_text(label);
-            }
+        if old.label != new.label
+            && let Some(label) = new.label.as_deref()
+        {
+            item.set_text(label);
         }
         if old.enabled != new.enabled {
             item.set_enabled(new.enabled);
@@ -822,7 +822,9 @@ mod tests {
             "tray menu should always expose the background process count: {labels:?}"
         );
         assert!(
-            labels.iter().any(|label| label == "Kill all background processes"),
+            labels
+                .iter()
+                .any(|label| label == "Kill all background processes"),
             "tray menu should expose a kill-all action even when there are no active sessions: {labels:?}"
         );
         assert!(
@@ -989,7 +991,14 @@ mod tests {
     fn tray_enabled_respects_explicit_disable() {
         let _guard = ENV_LOCK.lock().expect("env lock");
         let previous = std::env::var_os("TURA_GATEWAY_TRAY");
-        std::env::set_var("TURA_GATEWAY_TRAY", "0");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_GATEWAY_TRAY", "0")
+        };
 
         assert!(!tray_enabled());
 
@@ -1003,9 +1012,30 @@ mod tests {
         let previous_tray = std::env::var_os("TURA_GATEWAY_TRAY");
         let previous_display = std::env::var_os("DISPLAY");
         let previous_wayland = std::env::var_os("WAYLAND_DISPLAY");
-        std::env::remove_var("TURA_GATEWAY_TRAY");
-        std::env::remove_var("DISPLAY");
-        std::env::remove_var("WAYLAND_DISPLAY");
+        // SAFETY: the test environment guard serializes and restores these variables.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_GATEWAY_TRAY")
+        };
+        // SAFETY: the test environment guard serializes and restores these variables.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("DISPLAY")
+        };
+        // SAFETY: the test environment guard serializes and restores these variables.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("WAYLAND_DISPLAY")
+        };
 
         assert!(!tray_enabled());
 
@@ -1021,9 +1051,30 @@ mod tests {
         let previous_tray = std::env::var_os("TURA_GATEWAY_TRAY");
         let previous_display = std::env::var_os("DISPLAY");
         let previous_wayland = std::env::var_os("WAYLAND_DISPLAY");
-        std::env::remove_var("TURA_GATEWAY_TRAY");
-        std::env::set_var("DISPLAY", ":99");
-        std::env::remove_var("WAYLAND_DISPLAY");
+        // SAFETY: the test environment guard serializes and restores these variables.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_GATEWAY_TRAY")
+        };
+        // SAFETY: the test environment guard serializes and restores these variables.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("DISPLAY", ":99")
+        };
+        // SAFETY: the test environment guard serializes and restores these variables.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("WAYLAND_DISPLAY")
+        };
 
         assert!(tray_enabled());
 
@@ -1074,9 +1125,23 @@ mod tests {
 
     fn restore_env_var(name: &str, value: Option<OsString>) {
         if let Some(value) = value {
-            std::env::set_var(name, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(name, value)
+            };
         } else {
-            std::env::remove_var(name);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(name)
+            };
         }
     }
 

--- a/crates/gateway/src/tura_exec/env.rs
+++ b/crates/gateway/src/tura_exec/env.rs
@@ -3,36 +3,120 @@ use std::path::{Path, PathBuf};
 use super::cli::CliConfig;
 
 pub(crate) fn configure_runtime_env(config: &CliConfig) {
-    std::env::set_var("TURA_FRONTEND_SOURCE", "cli");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_FRONTEND_SOURCE", "cli")
+    };
     if let Some(model) = config.model.as_deref() {
-        std::env::set_var("TURA_SESSION_MODEL_OVERRIDE", normalize_model(model));
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_MODEL_OVERRIDE", normalize_model(model))
+        };
     }
     if let Some(reasoning) = config.reasoning_effort.as_deref() {
-        std::env::set_var("TURA_SESSION_REASONING_EFFORT", reasoning);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_REASONING_EFFORT", reasoning)
+        };
     }
     if config.priority {
-        std::env::set_var("TURA_SESSION_ACCELERATION_ENABLED", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_ACCELERATION_ENABLED", "1")
+        };
     }
     if config.goal_mode {
-        std::env::set_var("TURA_GOAL_MODE", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_GOAL_MODE", "1")
+        };
     } else {
-        std::env::remove_var("TURA_GOAL_MODE");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_GOAL_MODE")
+        };
     }
     if config.no_op_manual {
-        std::env::set_var("TURA_NO_OP_MANUAL", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_NO_OP_MANUAL", "1")
+        };
     } else {
-        std::env::remove_var("TURA_NO_OP_MANUAL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_NO_OP_MANUAL")
+        };
     }
     if let Some(max_tokens) = config.max_tokens {
-        std::env::set_var("TURA_SESSION_MAX_TOKENS", max_tokens.to_string());
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_MAX_TOKENS", max_tokens.to_string())
+        };
     }
     if let Some(shell) = config.command_run_shell.as_deref() {
-        std::env::set_var("TURA_COMMAND_RUN_SHELL", shell);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_SHELL", shell)
+        };
     }
     if config.command_run_sandbox {
-        std::env::set_var("TURA_COMMAND_RUN_SANDBOX", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_SANDBOX", "1")
+        };
     } else {
-        std::env::remove_var("TURA_COMMAND_RUN_SANDBOX");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_SANDBOX")
+        };
     }
     configure_release_runtime_env();
     configure_progress_env(config);
@@ -48,14 +132,49 @@ pub(crate) fn normalize_model(model: &str) -> String {
 
 fn configure_progress_env(config: &CliConfig) {
     if config.json {
-        std::env::set_var("TURA_CLI_LIVE_JSONL", "1");
-        std::env::remove_var("TURA_CLI_PROGRESS");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_CLI_LIVE_JSONL", "1")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_CLI_PROGRESS")
+        };
     } else {
-        std::env::remove_var("TURA_CLI_LIVE_JSONL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_CLI_LIVE_JSONL")
+        };
         if config.quiet {
-            std::env::remove_var("TURA_CLI_PROGRESS");
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("TURA_CLI_PROGRESS")
+            };
         } else {
-            std::env::set_var("TURA_CLI_PROGRESS", "1");
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_CLI_PROGRESS", "1")
+            };
         }
     }
 }
@@ -83,19 +202,40 @@ fn configure_release_runtime_env() {
         .unwrap_or_else(|| PathBuf::from(project_root_from_exe()))
         .display()
         .to_string();
-    std::env::set_var("TURA_PROJECT_ROOT", &root);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_PROJECT_ROOT", &root)
+    };
     if std::env::var_os("TURA_PROVIDER_CONFIG").is_none() {
         let provider_config = PathBuf::from(&root)
             .join("config")
             .join("provider_config.json");
         if provider_config.exists() {
-            std::env::set_var("TURA_PROVIDER_CONFIG", provider_config);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_PROVIDER_CONFIG", provider_config)
+            };
         }
     }
     if std::env::var_os("TURA_ENV_PATH").is_none() {
         let env_path = PathBuf::from(&root).join(".env");
         if env_path.exists() {
-            std::env::set_var("TURA_ENV_PATH", env_path);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_ENV_PATH", env_path)
+            };
         }
     }
 }

--- a/crates/gateway/src/tura_exec/mod.rs
+++ b/crates/gateway/src/tura_exec/mod.rs
@@ -52,16 +52,16 @@ fn run() -> Result<i32, String> {
     // from the persisted session. The CLI links no runtime/DB executor.
     if !config.embedded {
         let result = run_via_router(&config, &session_id, &prompt);
-        if let Err(error) = result.as_ref() {
-            if config.json {
-                emit_jsonl(&turn_completed_event(
-                    &config,
-                    &session_id,
-                    aggregate_runtime_usage(&[]),
-                    "failed",
-                    Some(error),
-                ))?;
-            }
+        if let Err(error) = result.as_ref()
+            && config.json
+        {
+            emit_jsonl(&turn_completed_event(
+                &config,
+                &session_id,
+                aggregate_runtime_usage(&[]),
+                "failed",
+                Some(error),
+            ))?;
         }
         return result;
     }
@@ -69,8 +69,22 @@ fn run() -> Result<i32, String> {
     // `--embedded` keeps its direct-worker behavior without linking the runtime
     // service into the gateway process.
     ensure_session_db_owner();
-    std::env::set_var("TURA_GATEWAY_CALLBACKS", "0");
-    std::env::set_var("TURA_RUNTIME_ERRORS_FATAL", "1");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_GATEWAY_CALLBACKS", "0")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_RUNTIME_ERRORS_FATAL", "1")
+    };
     if config.session_id.is_some() {
         reject_busy_session(&session_id, config.json)?;
     }

--- a/crates/gateway/src/tura_exec/router.rs
+++ b/crates/gateway/src/tura_exec/router.rs
@@ -91,10 +91,10 @@ pub(crate) fn run_via_router(
         write_last_message(path, &text)?;
     }
     let session_log = router_session_log(&response);
-    if config.log {
-        if let Some(session_log) = session_log.as_ref() {
-            write_turn_log_stderr(session_log, router_turn_started_at_ms(&response))?;
-        }
+    if config.log
+        && let Some(session_log) = session_log.as_ref()
+    {
+        write_turn_log_stderr(session_log, router_turn_started_at_ms(&response))?;
     }
     if config.json {
         emit_jsonl(
@@ -294,10 +294,10 @@ fn command_update_cli_event(
         if let Some(exit_code) = update.pointer("/result/exit_code") {
             item.insert("exit_code".to_string(), exit_code.clone());
         }
-        if item_type == "file_change" {
-            if let Some(changes) = command_update_changes(update) {
-                item.insert("changes".to_string(), changes);
-            }
+        if item_type == "file_change"
+            && let Some(changes) = command_update_changes(update)
+        {
+            item.insert("changes".to_string(), changes);
         }
     }
     prune_model_visible_cli_item(&mut item);
@@ -538,11 +538,11 @@ fn configure_router_stderr(command: &mut std::process::Command) {
         command.stderr(Stdio::null());
         return;
     };
-    if let Some(parent) = path.parent() {
-        if fs::create_dir_all(parent).is_err() {
-            command.stderr(Stdio::null());
-            return;
-        }
+    if let Some(parent) = path.parent()
+        && fs::create_dir_all(parent).is_err()
+    {
+        command.stderr(Stdio::null());
+        return;
     }
     match fs::OpenOptions::new().create(true).append(true).open(path) {
         Ok(file) => {
@@ -626,15 +626,14 @@ fn resolve_router_binary() -> Option<PathBuf> {
     };
     let mut candidates = Vec::new();
     let root = tura_path::canonical_root();
-    if let Ok(current_exe) = std::env::current_exe() {
-        if current_exe
+    if let Ok(current_exe) = std::env::current_exe()
+        && current_exe
             .parent()
             .and_then(std::path::Path::file_name)
             .and_then(|name| name.to_str())
             != Some("deps")
-        {
-            candidates.push(current_exe.with_file_name(executable));
-        }
+    {
+        candidates.push(current_exe.with_file_name(executable));
     }
     let profile = if tura_path::build_kind() == "release" {
         "release"
@@ -664,9 +663,23 @@ mod tests {
 
     fn restore_env(key: &str, value: Option<OsString>) {
         if let Some(value) = value {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         } else {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 
@@ -737,12 +750,54 @@ mod tests {
         let legacy_timeout_key = ["TURA_WORKER", "INVOKE_TIMEOUT_SECS"].join("_");
         let previous_timeout = std::env::var_os(&legacy_timeout_key);
 
-        std::env::set_var("TURA_SESSION_MAX_TOKENS", "4096");
-        std::env::set_var("TURA_GOAL_MODE", "1");
-        std::env::set_var("TURA_NO_OP_MANUAL", "1");
-        std::env::set_var("TURA_SESSION_LANGUAGE", "");
-        std::env::set_var("TURA_UNRELATED_ENV_FOR_TEST", "must-not-forward");
-        std::env::set_var(&legacy_timeout_key, "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_MAX_TOKENS", "4096")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_GOAL_MODE", "1")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_NO_OP_MANUAL", "1")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_LANGUAGE", "")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_UNRELATED_ENV_FOR_TEST", "must-not-forward")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(&legacy_timeout_key, "1")
+        };
 
         let env = worker_env_from_current_process();
 
@@ -771,16 +826,44 @@ mod tests {
         let previous_log = std::env::var_os("TURA_ROUTER_STDERR_LOG");
         let previous_debug = std::env::var_os("TURA_DEBUG_RUNTIME");
 
-        std::env::remove_var("TURA_ROUTER_STDERR_LOG");
-        std::env::remove_var("TURA_DEBUG_RUNTIME");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_ROUTER_STDERR_LOG")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DEBUG_RUNTIME")
+        };
         assert_eq!(router_stderr_log_path(), None);
 
-        std::env::set_var("TURA_DEBUG_RUNTIME", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_DEBUG_RUNTIME", "1")
+        };
         let debug_path = router_stderr_log_path().expect("debug path");
         assert!(debug_path.ends_with("router-daemon.stderr.log"));
 
         let explicit = std::env::temp_dir().join("explicit-router.stderr.log");
-        std::env::set_var("TURA_ROUTER_STDERR_LOG", &explicit);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_ROUTER_STDERR_LOG", &explicit)
+        };
         assert_eq!(router_stderr_log_path(), Some(explicit));
 
         restore_env("TURA_ROUTER_STDERR_LOG", previous_log);

--- a/crates/gateway/tests/business/file_api_local_flow.rs
+++ b/crates/gateway/tests/business/file_api_local_flow.rs
@@ -469,7 +469,14 @@ struct EnvGuard {
 impl EnvGuard {
     fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
         let previous = std::env::var_os(key);
-        std::env::set_var(key, value);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(key, value)
+        };
         Self { key, previous }
     }
 }
@@ -477,8 +484,26 @@ impl EnvGuard {
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         match self.previous.take() {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(self.key, value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(self.key)
+                }
+            }
         }
     }
 }

--- a/crates/gateway/tests/business/session_log_api_flow.rs
+++ b/crates/gateway/tests/business/session_log_api_flow.rs
@@ -268,9 +268,30 @@ impl EnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
         Self { previous }
     }
 }
@@ -279,8 +300,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..).rev() {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/tests/business/session_prompt_busy_flow.rs
+++ b/crates/gateway/tests/business/session_prompt_busy_flow.rs
@@ -439,7 +439,14 @@ impl TestSessionDb {
             .unwrap_or_else(|error| error.into_inner());
         let previous_home = std::env::var_os("TURA_HOME");
         let root = tempfile::tempdir().expect("busy-flow session DB root");
-        std::env::set_var("TURA_HOME", root.path());
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", root.path())
+        };
         let store = SessionLogStore::open_default().expect("open busy-flow session DB");
         let handle = std::thread::spawn(move || session_log::ipc::serve_blocking(store));
         let started = Instant::now();
@@ -471,8 +478,26 @@ impl Drop for TestSessionDb {
                 .expect("busy-flow session DB result");
         }
         match self.previous_home.take() {
-            Some(value) => std::env::set_var("TURA_HOME", value),
-            None => std::env::remove_var("TURA_HOME"),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("TURA_HOME", value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var("TURA_HOME")
+                }
+            }
         }
         let _ = self.root.path();
     }

--- a/crates/gateway/tests/business/workspace_config_api_flow.rs
+++ b/crates/gateway/tests/business/workspace_config_api_flow.rs
@@ -235,7 +235,8 @@ impl EnvGuard {
         let mut previous = Vec::new();
         for (key, value) in entries {
             previous.push((key, env::var_os(key)));
-            env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            unsafe { env::set_var(key, value) };
         }
         Self { entries: previous }
     }
@@ -245,9 +246,11 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.entries.drain(..).rev() {
             if let Some(value) = value {
-                env::set_var(key, value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                unsafe { env::set_var(key, value) };
             } else {
-                env::remove_var(key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                unsafe { env::remove_var(key) };
             }
         }
     }

--- a/crates/gateway/tests/config_split_test.rs
+++ b/crates/gateway/tests/config_split_test.rs
@@ -88,12 +88,54 @@ async fn tura_config_reads_configured_provider_model_options_and_updates_one_tie
 }"#,
     )
     .expect("config");
-    std::env::set_var("TURA_PROVIDER_CONFIG", &config_path);
-    std::env::set_var("OPENAI_API_KEY", "configured-codex");
-    std::env::set_var("GOOGLE_API_KEY", "");
-    std::env::set_var("GOOGLE_REFRESH_TOKEN", "");
-    std::env::set_var("CLAUDE_CODE_OAUTH_TOKEN", "");
-    std::env::set_var("CLAUDE_CODE_REFRESH_TOKEN", "configured-refresh");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_PROVIDER_CONFIG", &config_path)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", "configured-codex")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("GOOGLE_API_KEY", "")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("GOOGLE_REFRESH_TOKEN", "")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("CLAUDE_CODE_OAUTH_TOKEN", "")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("CLAUDE_CODE_REFRESH_TOKEN", "configured-refresh")
+    };
 
     let (status, body) = request(
         Method::GET,
@@ -177,8 +219,22 @@ fn temp_dir(name: &str) -> PathBuf {
 
 fn restore_env(key: &str, value: Option<String>) {
     if let Some(value) = value {
-        std::env::set_var(key, value);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(key, value)
+        };
     } else {
-        std::env::remove_var(key);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(key)
+        };
     }
 }

--- a/crates/gateway/tests/live/helpers/provider_oauth_local.rs
+++ b/crates/gateway/tests/live/helpers/provider_oauth_local.rs
@@ -365,8 +365,26 @@ impl EnvGuard {
             .collect::<Vec<_>>();
         for (key, value) in values {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
         Self { previous }
@@ -383,7 +401,14 @@ impl DynamicEnvGuard {
             .into_iter()
             .map(|key| {
                 let value = std::env::var_os(&key);
-                std::env::remove_var(&key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(&key)
+                };
                 (key, value)
             })
             .collect();
@@ -395,8 +420,26 @@ impl Drop for DynamicEnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }
@@ -406,8 +449,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/tests/live/provider_oauth_local_flow.rs
+++ b/crates/gateway/tests/live/provider_oauth_local_flow.rs
@@ -154,7 +154,14 @@ async fn oauth_business_pkce_flow_exchanges_local_token_and_persists_auth() {
         "refresh_token": "local-refresh-token",
         "expires_in": 7200
     }));
-    std::env::set_var("OPENAI_OAUTH_TOKEN_URL", token_server.url());
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_OAUTH_TOKEN_URL", token_server.url())
+    };
 
     let Json(response) = oauth_callback(
         Path(provider_id.to_string()),
@@ -269,7 +276,14 @@ async fn oauth_business_refresh_flow_uses_local_token_endpoint_and_updates_auth(
         "refresh_token": "refreshed-refresh-token",
         "expires_in": 3600
     }));
-    std::env::set_var("OPENAI_OAUTH_TOKEN_URL", token_server.url());
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_OAUTH_TOKEN_URL", token_server.url())
+    };
 
     let Json(response) = provider_auth_refresh(Path(provider_id.to_string())).await;
 
@@ -396,7 +410,14 @@ async fn oauth_business_validate_flow_reports_local_success_and_missing_key_deta
     );
 
     write_local_provider_config(&provider_config, "https://business.example.invalid/v1");
-    std::env::remove_var("BUSINESS_LOCAL_API_KEY");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("BUSINESS_LOCAL_API_KEY")
+    };
     let Json(invalid) = provider_auth_validate(
         Path("business-local".to_string()),
         Json(ProviderAuthValidationRequest::default()),

--- a/crates/gateway/tests/os_testing/helpers/session_prompt_router.rs
+++ b/crates/gateway/tests/os_testing/helpers/session_prompt_router.rs
@@ -76,14 +76,70 @@ impl EnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::set_var("TURA_PROJECT_ROOT", workspace);
-        std::env::set_var("TURA_CWD", workspace);
-        std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "1000");
-        std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", "5000");
-        std::env::set_var("TURA_GATEWAY_ALLOW_IN_PROCESS_FAKE_ROUTER", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", workspace)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_CWD", workspace)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "1000")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", "5000")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_GATEWAY_ALLOW_IN_PROCESS_FAKE_ROUTER", "1")
+        };
         Self { previous }
     }
 }
@@ -92,8 +148,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/tests/os_testing/helpers/task_scheduler.rs
+++ b/crates/gateway/tests/os_testing/helpers/task_scheduler.rs
@@ -282,11 +282,46 @@ impl SchedulerEnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "1000");
-        std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", "5000");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "1000")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", "5000")
+        };
         Self { previous }
     }
 }
@@ -295,8 +330,26 @@ impl Drop for SchedulerEnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/tests/os_testing/process_router_cleanup_flow.rs
+++ b/crates/gateway/tests/os_testing/process_router_cleanup_flow.rs
@@ -228,12 +228,54 @@ impl EnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::set_var("TURA_PROJECT_ROOT", repo_root());
-        std::env::set_var("TURA_CWD", workspace);
-        std::env::set_var("TURA_ROUTER_IDLE_SHUTDOWN_SECS", "2");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", repo_root())
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_CWD", workspace)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_ROUTER_IDLE_SHUTDOWN_SECS", "2")
+        };
         Self { previous }
     }
 }
@@ -242,8 +284,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/tests/os_testing/service_status_flow.rs
+++ b/crates/gateway/tests/os_testing/service_status_flow.rs
@@ -285,10 +285,38 @@ impl EnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::set_var("TURA_GATEWAY_ALLOW_IN_PROCESS_FAKE_ROUTER", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_GATEWAY_ALLOW_IN_PROCESS_FAKE_ROUTER", "1")
+        };
         Self { previous }
     }
 }
@@ -297,8 +325,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/tests/os_testing/session_db_local_flow.rs
+++ b/crates/gateway/tests/os_testing/session_db_local_flow.rs
@@ -360,11 +360,46 @@ impl EnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "1000");
-        std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", "5000");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "1000")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", "5000")
+        };
         Self { previous }
     }
 }
@@ -373,8 +408,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/tests/performance/gateway_session_concurrency_stress.rs
+++ b/crates/gateway/tests/performance/gateway_session_concurrency_stress.rs
@@ -473,13 +473,62 @@ impl EnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::set_var("TURA_PROJECT_ROOT", workspace);
-        std::env::set_var("TURA_CWD", workspace);
-        std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "1000");
-        std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", "5000");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", workspace)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_CWD", workspace)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "1000")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", "5000")
+        };
         Self { previous }
     }
 }
@@ -488,8 +537,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/tests/performance/provider_auth_churn_test.rs
+++ b/crates/gateway/tests/performance/provider_auth_churn_test.rs
@@ -237,8 +237,26 @@ impl EnvGuard {
             .collect::<Vec<_>>();
         for (key, value) in values {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
         Self { previous }
@@ -249,8 +267,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }
@@ -266,7 +302,14 @@ impl DynamicEnvGuard {
             .into_iter()
             .map(|key| {
                 let value = std::env::var_os(&key);
-                std::env::remove_var(&key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(&key)
+                };
                 (key, value)
             })
             .collect();
@@ -278,8 +321,26 @@ impl Drop for DynamicEnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/tests/support/mod.rs
+++ b/crates/gateway/tests/support/mod.rs
@@ -22,9 +22,30 @@ impl TestSessionDb {
         let workspace = root.path().join("workspace");
         std::fs::create_dir_all(&home)?;
         std::fs::create_dir_all(&workspace)?;
-        std::env::set_var("TURA_HOME", &home);
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", &home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
 
         let store = SessionLogStore::open_default()?;
         let handle = std::thread::spawn(move || session_log::ipc::serve_blocking(store));
@@ -85,8 +106,26 @@ impl Drop for EnvRestore {
     fn drop(&mut self) {
         for (key, value) in self.keys.drain(..).rev() {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/lifecycle/src/lib.rs
+++ b/crates/lifecycle/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::unwrap_used)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 mod runtime;
 mod session;

--- a/crates/lifecycle/src/session_management.rs
+++ b/crates/lifecycle/src/session_management.rs
@@ -1075,9 +1075,23 @@ mod tests {
 
     fn restore_env(key: &str, value: Option<OsString>) {
         if let Some(value) = value {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         } else {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 
@@ -1219,7 +1233,14 @@ mod tests {
     fn goal_mode_records_last_goal_user_input_from_env() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
         let previous = std::env::var_os("TURA_GOAL_MODE");
-        std::env::set_var("TURA_GOAL_MODE", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_GOAL_MODE", "1")
+        };
 
         let mut session = session_in_state(SessionState::Completed);
 
@@ -1246,11 +1267,25 @@ mod tests {
     fn non_goal_turn_does_not_overwrite_recorded_goal_input() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
         let previous = std::env::var_os("TURA_GOAL_MODE");
-        std::env::set_var("TURA_GOAL_MODE", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_GOAL_MODE", "1")
+        };
         let mut session = session_in_state(SessionState::Completed);
         assert_eq!(session.last_goal_user_input, "first");
 
-        std::env::remove_var("TURA_GOAL_MODE");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_GOAL_MODE")
+        };
         session.prepare_for_new_user_turn(
             SessionInput {
                 user_input: "ordinary follow-up".to_string(),

--- a/crates/lifecycle/src/session_projection.rs
+++ b/crates/lifecycle/src/session_projection.rs
@@ -49,10 +49,10 @@ pub(crate) fn task_management_json(
             "start_at": task.map(|task| task.start_at).unwrap_or(session_started_at),
             "poll_interval": task.map(|task| task.poll_interval).unwrap_or_default(),
         });
-        if let Some(task) = task {
-            if let Some(task_state) = task_state_value(task) {
-                value["status"] = task_state;
-            }
+        if let Some(task) = task
+            && let Some(task_state) = task_state_value(task)
+        {
+            value["status"] = task_state;
         }
         return value;
     }

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -296,13 +296,27 @@ mod tests {
     fn instance_home_honors_explicit_override() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let temp = std::env::temp_dir();
-        std::env::set_var("TURA_HOME", &temp);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", &temp)
+        };
         // Normalization resolves to the same home regardless of trailing slash
         // or case differences the OS treats as equivalent.
         let home = instance_home();
         let expected = normalize_path(&temp);
         assert_eq!(home, expected);
-        std::env::remove_var("TURA_HOME");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_HOME")
+        };
     }
 
     #[test]
@@ -310,12 +324,26 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let temp = std::env::temp_dir().join("tura-path-derive-test");
         std::fs::create_dir_all(&temp).expect("create temp TURA_HOME");
-        std::env::set_var("TURA_HOME", &temp);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", &temp)
+        };
         let home = instance_home();
         assert!(home_socket("session_db").starts_with(&home));
         assert!(locks_dir().starts_with(&home));
         assert!(home_runtime_dir().starts_with(&home));
-        std::env::remove_var("TURA_HOME");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_HOME")
+        };
     }
 
     #[test]
@@ -370,7 +398,14 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let temp = tempfile::tempdir().expect("temp root");
         let previous = std::env::var_os("TURA_PROJECT_ROOT");
-        std::env::set_var("TURA_PROJECT_ROOT", temp.path());
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", temp.path())
+        };
 
         let root = canonical_root();
 
@@ -382,7 +417,14 @@ mod tests {
     fn canonical_root_ignores_missing_project_root_env() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let previous = std::env::var_os("TURA_PROJECT_ROOT");
-        std::env::set_var("TURA_PROJECT_ROOT", "Z:/definitely/missing/tura/root");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", "Z:/definitely/missing/tura/root")
+        };
 
         let root = canonical_root();
 
@@ -396,7 +438,14 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let temp = tempfile::tempdir().expect("temp home");
         let previous = std::env::var_os("TURA_HOME");
-        std::env::set_var("TURA_HOME", temp.path());
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", temp.path())
+        };
 
         assert_eq!(
             home_runtime_dir(),
@@ -442,12 +491,33 @@ mod tests {
         let tura_root = temp.path().join("tura-root");
         let previous_session = std::env::var_os("SESSION_LOG_DB_ROOT");
         let previous_tura = std::env::var_os("TURA_DB_ROOT");
-        std::env::set_var("SESSION_LOG_DB_ROOT", &session_root);
-        std::env::set_var("TURA_DB_ROOT", &tura_root);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("SESSION_LOG_DB_ROOT", &session_root)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_DB_ROOT", &tura_root)
+        };
 
         assert_eq!(home_db_dir(), session_root.join(DB_DIR_NAME));
 
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
         assert_eq!(home_db_dir(), tura_root.join(DB_DIR_NAME));
 
         restore_env("SESSION_LOG_DB_ROOT", previous_session);
@@ -461,9 +531,30 @@ mod tests {
         let previous_home = std::env::var_os("TURA_HOME");
         let previous_session = std::env::var_os("SESSION_LOG_DB_ROOT");
         let previous_tura = std::env::var_os("TURA_DB_ROOT");
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::set_var("TURA_HOME", temp.path());
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", temp.path())
+        };
 
         assert_eq!(
             home_db_dir(),
@@ -499,9 +590,23 @@ mod tests {
 
     fn restore_env(key: &str, previous: Option<std::ffi::OsString>) {
         if let Some(value) = previous {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         } else {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 }

--- a/crates/path/src/process_hardening.rs
+++ b/crates/path/src/process_hardening.rs
@@ -91,7 +91,14 @@ pub fn remove_dangerous_env_vars(
     let mut removed = Vec::new();
     for (key, _) in vars {
         if dangerous_env_key(&key) {
-            std::env::remove_var(&key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(&key)
+            };
             removed.push(key);
         }
     }
@@ -268,9 +275,30 @@ mod tests {
         let previous_ld = std::env::var_os("LD_PRELOAD");
         let previous_dyld = std::env::var_os("DYLD_TEST_REMOVE");
         let previous_safe = std::env::var_os("TURA_SAFE_TEST_ENV");
-        std::env::set_var("LD_PRELOAD", "inject.so");
-        std::env::set_var("DYLD_TEST_REMOVE", "inject.dylib");
-        std::env::set_var("TURA_SAFE_TEST_ENV", "keep");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("LD_PRELOAD", "inject.so")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("DYLD_TEST_REMOVE", "inject.dylib")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SAFE_TEST_ENV", "keep")
+        };
 
         let removed = remove_dangerous_env_vars([
             (OsString::from("LD_PRELOAD"), OsString::from("inject.so")),
@@ -338,9 +366,23 @@ mod tests {
 
     fn restore_env(key: &str, previous: Option<OsString>) {
         if let Some(value) = previous {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         } else {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 }

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::unwrap_used)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 pub mod auth_registry;
 pub mod content_type_fallback;

--- a/crates/provider/src/llm/claude_code.rs
+++ b/crates/provider/src/llm/claude_code.rs
@@ -218,23 +218,23 @@ impl AnthropicStreamState {
                 }
             }
             Some("content_block_delta") => {
-                if let Some(index) = event.get("index").and_then(Value::as_u64) {
-                    if let Some(delta) = event.get("delta") {
-                        self.apply_delta(index as usize, delta);
-                        output_started = true;
-                        if delta.get("type").and_then(Value::as_str) == Some("text_delta") {
-                            if let (Some(sink), Some(text)) = (
-                                stream_events,
-                                delta
-                                    .get("text")
-                                    .and_then(Value::as_str)
-                                    .filter(|text| !text.is_empty()),
-                            ) {
-                                sink(ProviderStreamEvent::TextDelta {
-                                    text: text.to_string(),
-                                });
-                            }
-                        }
+                if let Some(index) = event.get("index").and_then(Value::as_u64)
+                    && let Some(delta) = event.get("delta")
+                {
+                    self.apply_delta(index as usize, delta);
+                    output_started = true;
+                    if delta.get("type").and_then(Value::as_str) == Some("text_delta")
+                        && let (Some(sink), Some(text)) = (
+                            stream_events,
+                            delta
+                                .get("text")
+                                .and_then(Value::as_str)
+                                .filter(|text| !text.is_empty()),
+                        )
+                    {
+                        sink(ProviderStreamEvent::TextDelta {
+                            text: text.to_string(),
+                        });
                     }
                 }
             }
@@ -301,10 +301,10 @@ impl AnthropicStreamState {
         let Some(block) = self.content.get_mut(&index) else {
             return;
         };
-        if let Some(buffer) = self.tool_input_buffers.remove(&index) {
-            if let Ok(input) = serde_json::from_str::<Value>(&buffer) {
-                block["input"] = input;
-            }
+        if let Some(buffer) = self.tool_input_buffers.remove(&index)
+            && let Ok(input) = serde_json::from_str::<Value>(&buffer)
+        {
+            block["input"] = input;
         }
         for event in command_run_events_from_anthropic_tool_block(block) {
             if let Some(sink) = stream_events {
@@ -504,11 +504,11 @@ fn convert_messages(messages: &[Value], oauth: bool) -> (Vec<Value>, Vec<Value>)
     let mut blocks: Vec<(String, Vec<Value>)> = Vec::new();
 
     let mut push = |role: &str, block: Value| {
-        if let Some((last_role, last_blocks)) = blocks.last_mut() {
-            if last_role == role {
-                last_blocks.push(block);
-                return;
-            }
+        if let Some((last_role, last_blocks)) = blocks.last_mut()
+            && last_role == role
+        {
+            last_blocks.push(block);
+            return;
         }
         blocks.push((role.to_string(), vec![block]));
     };
@@ -540,10 +540,10 @@ fn convert_messages(messages: &[Value], oauth: bool) -> (Vec<Value>, Vec<Value>)
                 push("user", chat_tool_result_block(message));
             }
             "assistant" => {
-                if let Some(text) = message_text(message.get("content")) {
-                    if !text.trim().is_empty() {
-                        push("assistant", json!({ "type": "text", "text": text }));
-                    }
+                if let Some(text) = message_text(message.get("content"))
+                    && !text.trim().is_empty()
+                {
+                    push("assistant", json!({ "type": "text", "text": text }));
                 }
                 for tool_use in chat_tool_use_blocks(message) {
                     push("assistant", tool_use);

--- a/crates/provider/src/llm/google.rs
+++ b/crates/provider/src/llm/google.rs
@@ -266,11 +266,12 @@ fn push_google_function_response(contents: &mut Vec<Value>, part: Value) {
                     .iter()
                     .any(|part| part.get("functionResponse").is_some())
             });
-    if last.get("role").and_then(Value::as_str) == Some("user") && last_has_function_response {
-        if let Some(parts) = last.get_mut("parts").and_then(Value::as_array_mut) {
-            parts.push(part);
-            return;
-        }
+    if last.get("role").and_then(Value::as_str) == Some("user")
+        && last_has_function_response
+        && let Some(parts) = last.get_mut("parts").and_then(Value::as_array_mut)
+    {
+        parts.push(part);
+        return;
     }
     contents.push(json!({ "role": "user", "parts": [part] }));
 }
@@ -318,20 +319,19 @@ fn build_tool_config(tool_choice: Option<&Value>) -> Option<Value> {
             _ => None, // "auto" or unknown → let the model decide
         },
         Value::Object(_) => {
-            if choice.get("type").and_then(Value::as_str) == Some("function") {
-                if let Some(name) = choice
+            if choice.get("type").and_then(Value::as_str) == Some("function")
+                && let Some(name) = choice
                     .get("function")
                     .and_then(|f| f.get("name"))
                     .and_then(Value::as_str)
                     .filter(|n| !n.trim().is_empty())
-                {
-                    return Some(json!({
-                        "functionCallingConfig": {
-                            "mode": "ANY",
-                            "allowedFunctionNames": [name]
-                        }
-                    }));
-                }
+            {
+                return Some(json!({
+                    "functionCallingConfig": {
+                        "mode": "ANY",
+                        "allowedFunctionNames": [name]
+                    }
+                }));
             }
             None
         }

--- a/crates/provider/src/llm/openapi/chat.rs
+++ b/crates/provider/src/llm/openapi/chat.rs
@@ -596,27 +596,26 @@ fn process_openai_compatible_stream_line(
         .and_then(|c| c.as_array())
         .and_then(|a| a.first())
     {
-        if let Some(delta_content) = choice.get("delta").and_then(|d| d.get("content")) {
-            if let Some(text) = delta_content
+        if let Some(delta_content) = choice.get("delta").and_then(|d| d.get("content"))
+            && let Some(text) = delta_content
                 .as_str()
                 .filter(|_| !state.completed_tool_call)
-            {
-                if !text.is_empty() {
-                    output_event = true;
-                    if let Some(sink) = stream_events {
-                        sink(ProviderStreamEvent::TextDelta {
-                            text: text.to_string(),
-                        });
-                    }
+        {
+            if !text.is_empty() {
+                output_event = true;
+                if let Some(sink) = stream_events {
+                    sink(ProviderStreamEvent::TextDelta {
+                        text: text.to_string(),
+                    });
                 }
-                full_content.push_str(text);
-                if emit_minimax_streaming_tool_call(
-                    full_content,
-                    &mut state.tool_call_buffers,
-                    tool_calls,
-                ) {
-                    state.completed_tool_call = true;
-                }
+            }
+            full_content.push_str(text);
+            if emit_minimax_streaming_tool_call(
+                full_content,
+                &mut state.tool_call_buffers,
+                tool_calls,
+            ) {
+                state.completed_tool_call = true;
             }
         }
         if let Some(reasoning) = choice
@@ -634,48 +633,48 @@ fn process_openai_compatible_stream_line(
                 state.reasoning_buffer.push_str(reasoning);
             }
         }
-        if let Some(tool_calls_delta) = choice.get("delta").and_then(|d| d.get("tool_calls")) {
-            if let Some(calls) = tool_calls_delta.as_array() {
-                if !calls.is_empty() {
-                    output_event = true;
+        if let Some(tool_calls_delta) = choice.get("delta").and_then(|d| d.get("tool_calls"))
+            && let Some(calls) = tool_calls_delta.as_array()
+        {
+            if !calls.is_empty() {
+                output_event = true;
+            }
+            for call in calls {
+                let key = call
+                    .get("index")
+                    .and_then(Value::as_u64)
+                    .map(|index| index.to_string())
+                    .or_else(|| {
+                        call.get("id")
+                            .and_then(Value::as_str)
+                            .map(ToString::to_string)
+                    })
+                    .unwrap_or_else(|| "0".to_string());
+                let buffer = state.tool_call_buffers.entry(key).or_default();
+                if let Some(id) = call
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .filter(|id| !id.trim().is_empty())
+                {
+                    buffer.id = Some(id.to_string());
                 }
-                for call in calls {
-                    let key = call
-                        .get("index")
-                        .and_then(Value::as_u64)
-                        .map(|index| index.to_string())
-                        .or_else(|| {
-                            call.get("id")
-                                .and_then(Value::as_str)
-                                .map(ToString::to_string)
-                        })
-                        .unwrap_or_else(|| "0".to_string());
-                    let buffer = state.tool_call_buffers.entry(key).or_default();
-                    if let Some(id) = call
-                        .get("id")
-                        .and_then(Value::as_str)
-                        .filter(|id| !id.trim().is_empty())
-                    {
-                        buffer.id = Some(id.to_string());
-                    }
-                    if let Some(name) = call
-                        .get("function")
-                        .and_then(|f| f.get("name"))
-                        .and_then(Value::as_str)
-                        .filter(|name| !name.trim().is_empty())
-                    {
-                        buffer.name = Some(name.to_string());
-                    }
-                    if let Some(args) = call
-                        .get("function")
-                        .and_then(|f| f.get("arguments"))
-                        .and_then(Value::as_str)
-                    {
-                        buffer.arguments.push_str(args);
-                    }
-                    if emit_completed_tool_call(buffer, tool_calls) {
-                        state.completed_tool_call = true;
-                    }
+                if let Some(name) = call
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(Value::as_str)
+                    .filter(|name| !name.trim().is_empty())
+                {
+                    buffer.name = Some(name.to_string());
+                }
+                if let Some(args) = call
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(Value::as_str)
+                {
+                    buffer.arguments.push_str(args);
+                }
+                if emit_completed_tool_call(buffer, tool_calls) {
+                    state.completed_tool_call = true;
                 }
             }
         }

--- a/crates/provider/src/llm/openapi/mod_tests.rs
+++ b/crates/provider/src/llm/openapi/mod_tests.rs
@@ -418,8 +418,9 @@ async fn streaming_provider_drains_usage_after_tool_arguments_complete() {
                 "prompt_tokens_details": {"cached_tokens": 2048}
             }
         });
-        let body =
-                format!("data: {first}\n\ndata: {second}\n\ndata: {late_text}\n\ndata: {usage}\n\ndata: [DONE]\n\n");
+        let body = format!(
+            "data: {first}\n\ndata: {second}\n\ndata: {late_text}\n\ndata: {usage}\n\ndata: [DONE]\n\n"
+        );
         let response = format!(
             "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\n\r\n{}",
             body.len(),
@@ -600,8 +601,22 @@ async fn codex_oauth_call_sends_responses_reasoning_and_acceleration() {
     let endpoint = format!("http://{addr}/backend-api/codex/responses");
     let previous_endpoint = std::env::var_os("OPENAI_CODEX_ENDPOINT");
     let previous_account_id = std::env::var_os("OPENAI_ACCOUNT_ID");
-    std::env::set_var("OPENAI_CODEX_ENDPOINT", &endpoint);
-    std::env::set_var("OPENAI_ACCOUNT_ID", "acct-probe");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_CODEX_ENDPOINT", &endpoint)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_ACCOUNT_ID", "acct-probe")
+    };
     let (tx, rx) = mpsc::channel();
 
     std::thread::spawn(move || {
@@ -638,10 +653,10 @@ async fn codex_oauth_call_sends_responses_reasoning_and_acceleration() {
         }
 
         let body = concat!(
-                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n",
-                "data: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"ok\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n",
-                "data: [DONE]\n\n"
-            );
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"ok\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n",
+            "data: [DONE]\n\n"
+        );
         let response = format!(
             "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\n\r\n{}",
             body.len(),
@@ -663,12 +678,48 @@ async fn codex_oauth_call_sends_responses_reasoning_and_acceleration() {
         super::codex_oauth_call("gpt-5.1-codex", "test-token", &messages, &options, None).await;
 
     match previous_endpoint {
-        Some(value) => std::env::set_var("OPENAI_CODEX_ENDPOINT", value),
-        None => std::env::remove_var("OPENAI_CODEX_ENDPOINT"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("OPENAI_CODEX_ENDPOINT", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("OPENAI_CODEX_ENDPOINT")
+            }
+        }
     }
     match previous_account_id {
-        Some(value) => std::env::set_var("OPENAI_ACCOUNT_ID", value),
-        None => std::env::remove_var("OPENAI_ACCOUNT_ID"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("OPENAI_ACCOUNT_ID", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("OPENAI_ACCOUNT_ID")
+            }
+        }
     }
 
     result.expect("codex oauth call");
@@ -698,7 +749,14 @@ async fn codex_oauth_stream_reads_completed_usage_after_tool_call() {
     let addr = listener.local_addr().expect("local addr");
     let endpoint = format!("http://{addr}/backend-api/codex/responses");
     let previous_endpoint = std::env::var_os("OPENAI_CODEX_ENDPOINT");
-    std::env::set_var("OPENAI_CODEX_ENDPOINT", &endpoint);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_CODEX_ENDPOINT", &endpoint)
+    };
 
     std::thread::spawn(move || {
         let (mut stream, _) = listener.accept().expect("accept request");
@@ -787,8 +845,26 @@ async fn codex_oauth_stream_reads_completed_usage_after_tool_call() {
     .await;
 
     match previous_endpoint {
-        Some(value) => std::env::set_var("OPENAI_CODEX_ENDPOINT", value),
-        None => std::env::remove_var("OPENAI_CODEX_ENDPOINT"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("OPENAI_CODEX_ENDPOINT", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("OPENAI_CODEX_ENDPOINT")
+            }
+        }
     }
 
     let metrics = result.expect("codex oauth call").metrics.expect("metrics");

--- a/crates/provider/src/llm/openapi/response.rs
+++ b/crates/provider/src/llm/openapi/response.rs
@@ -48,10 +48,10 @@ pub(crate) async fn codex_oauth_call(
         request = request.header("session_id", "tura-codex-validation");
     }
 
-    if let Ok(account_id) = std::env::var("OPENAI_ACCOUNT_ID") {
-        if !account_id.trim().is_empty() {
-            request = request.header("ChatGPT-Account-Id", account_id);
-        }
+    if let Ok(account_id) = std::env::var("OPENAI_ACCOUNT_ID")
+        && !account_id.trim().is_empty()
+    {
+        request = request.header("ChatGPT-Account-Id", account_id);
     }
 
     let resp = send_provider_request_first_response(request).await?;
@@ -326,10 +326,10 @@ fn codex_content_item_for_role(role: &str, item: Value) -> Value {
         .get("text")
         .and_then(Value::as_str)
         .or_else(|| item.get("content").and_then(Value::as_str));
-    if matches!(kind, "input_text" | "text" | "output_text") {
-        if let Some(text) = text {
-            return codex_text_item(role, text.to_string());
-        }
+    if matches!(kind, "input_text" | "text" | "output_text")
+        && let Some(text) = text
+    {
+        return codex_text_item(role, text.to_string());
     }
     item
 }
@@ -426,16 +426,15 @@ fn process_codex_sse_line(
         if output_event {
             sink(ProviderStreamEvent::ProviderOutputStarted);
         }
-        if value.get("type").and_then(Value::as_str) == Some("response.output_text.delta") {
-            if let Some(delta) = value
+        if value.get("type").and_then(Value::as_str) == Some("response.output_text.delta")
+            && let Some(delta) = value
                 .get("delta")
                 .and_then(Value::as_str)
                 .filter(|delta| !delta.is_empty())
-            {
-                sink(ProviderStreamEvent::TextDelta {
-                    text: delta.to_string(),
-                });
-            }
+        {
+            sink(ProviderStreamEvent::TextDelta {
+                text: delta.to_string(),
+            });
         }
         for event in command_collector.push_event(&value) {
             sink(event);
@@ -549,10 +548,10 @@ pub(crate) fn normalize_codex_response_event_content(data: &Value) -> Option<Val
     let tool_calls = complete_codex_tool_calls(data);
     if !tool_calls.is_empty() {
         let mut object = serde_json::Map::new();
-        if let Some(text) = data.get("output_text").and_then(Value::as_str) {
-            if !text.trim().is_empty() {
-                object.insert("text".to_string(), Value::String(text.to_string()));
-            }
+        if let Some(text) = data.get("output_text").and_then(Value::as_str)
+            && !text.trim().is_empty()
+        {
+            object.insert("text".to_string(), Value::String(text.to_string()));
         }
         object.insert("tool_calls".to_string(), Value::Array(tool_calls));
         return Some(Value::Object(object));
@@ -608,18 +607,17 @@ fn codex_tool_schema(tool: &Value) -> Value {
 }
 
 fn normalize_codex_tool_choice(tool_choice: &Value) -> Value {
-    if tool_choice.get("type").and_then(Value::as_str) == Some("function") {
-        if let Some(name) = tool_choice
+    if tool_choice.get("type").and_then(Value::as_str) == Some("function")
+        && let Some(name) = tool_choice
             .get("function")
             .and_then(|function| function.get("name"))
             .and_then(Value::as_str)
             .filter(|name| !name.trim().is_empty())
-        {
-            return json!({
-                "type": "function",
-                "name": name,
-            });
-        }
+    {
+        return json!({
+            "type": "function",
+            "name": name,
+        });
     }
     tool_choice.clone()
 }

--- a/crates/provider/src/llm/openapi/response_tool_stream.rs
+++ b/crates/provider/src/llm/openapi/response_tool_stream.rs
@@ -28,10 +28,10 @@ struct CodexToolCallEntry {
 
 impl CodexToolCallStreamCollector {
     pub(crate) fn push_event(&mut self, event: &Value) -> Vec<Value> {
-        if let Some(item) = event.get("item") {
-            if item.get("type").and_then(Value::as_str) == Some("function_call") {
-                self.upsert_item(item);
-            }
+        if let Some(item) = event.get("item")
+            && item.get("type").and_then(Value::as_str) == Some("function_call")
+        {
+            self.upsert_item(item);
         }
 
         match event.get("type").and_then(Value::as_str) {
@@ -39,10 +39,9 @@ impl CodexToolCallStreamCollector {
                 if let (Some(id), Some(delta)) = (
                     self.event_tool_id(event),
                     event.get("delta").and_then(Value::as_str),
-                ) {
-                    if let Some(entry) = self.entry_mut(&id) {
-                        entry.arguments.push_str(delta);
-                    }
+                ) && let Some(entry) = self.entry_mut(&id)
+                {
+                    entry.arguments.push_str(delta);
                 }
                 Vec::new()
             }
@@ -175,10 +174,10 @@ struct CodexCommandRunCommandEntry {
 
 impl CodexCommandRunCommandCollector {
     pub(crate) fn push_event(&mut self, event: &Value) -> Vec<ProviderStreamEvent> {
-        if let Some(item) = event.get("item") {
-            if item.get("type").and_then(Value::as_str) == Some("function_call") {
-                self.upsert_item(item);
-            }
+        if let Some(item) = event.get("item")
+            && item.get("type").and_then(Value::as_str) == Some("function_call")
+        {
+            self.upsert_item(item);
         }
 
         match event.get("type").and_then(Value::as_str) {
@@ -186,11 +185,10 @@ impl CodexCommandRunCommandCollector {
                 if let (Some(id), Some(delta)) = (
                     self.event_tool_id(event),
                     event.get("delta").and_then(Value::as_str),
-                ) {
-                    if let Some(entry) = self.entry_mut(&id) {
-                        entry.arguments.push_str(delta);
-                        return Self::emit_ready_commands(entry);
-                    }
+                ) && let Some(entry) = self.entry_mut(&id)
+                {
+                    entry.arguments.push_str(delta);
+                    return Self::emit_ready_commands(entry);
                 }
                 Vec::new()
             }
@@ -198,11 +196,10 @@ impl CodexCommandRunCommandCollector {
                 if let (Some(id), Some(arguments)) = (
                     self.event_tool_id(event),
                     event.get("arguments").and_then(Value::as_str),
-                ) {
-                    if let Some(entry) = self.entry_mut(&id) {
-                        entry.arguments = arguments.to_string();
-                        return Self::emit_ready_commands(entry);
-                    }
+                ) && let Some(entry) = self.entry_mut(&id)
+                {
+                    entry.arguments = arguments.to_string();
+                    return Self::emit_ready_commands(entry);
                 }
                 Vec::new()
             }
@@ -329,14 +326,11 @@ fn complete_command_run_command_objects(arguments: &str) -> Vec<Value> {
             '}' => {
                 if depth > 0 {
                     depth -= 1;
-                    if depth == 0 {
-                        if let Some(start) = object_start.take() {
-                            if let Ok(value) =
-                                serde_json::from_str::<Value>(&arguments[start..=index])
-                            {
-                                commands.push(value);
-                            }
-                        }
+                    if depth == 0
+                        && let Some(start) = object_start.take()
+                        && let Ok(value) = serde_json::from_str::<Value>(&arguments[start..=index])
+                    {
+                        commands.push(value);
                     }
                 }
             }
@@ -366,10 +360,10 @@ fn find_commands_array_start(arguments: &str) -> Option<usize> {
             }
             if ch == '"' {
                 in_string = false;
-                if let Some(start) = key_start.take() {
-                    if let Ok(key) = serde_json::from_str::<String>(&arguments[start..=index]) {
-                        last_key = Some(key);
-                    }
+                if let Some(start) = key_start.take()
+                    && let Ok(key) = serde_json::from_str::<String>(&arguments[start..=index])
+                {
+                    last_key = Some(key);
                 }
             }
             continue;

--- a/crates/provider/src/logging.rs
+++ b/crates/provider/src/logging.rs
@@ -172,10 +172,24 @@ mod tests {
     }
 
     fn set_env(key: &str, value: &str) {
-        std::env::set_var(key, value);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(key, value)
+        };
     }
 
     fn remove_env(key: &str) {
-        std::env::remove_var(key);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(key)
+        };
     }
 }

--- a/crates/provider/src/response_extraction.rs
+++ b/crates/provider/src/response_extraction.rs
@@ -69,35 +69,32 @@ pub fn extract_tool_calls(content: &Value) -> Vec<ProviderToolCall> {
 
     if let Some(tool_calls) = content.get("tool_calls").and_then(Value::as_array) {
         for call in tool_calls {
-            if let Some(function) = call.get("function") {
-                if let Some(name) = function.get("name").and_then(Value::as_str) {
-                    let arguments = function.get("arguments").cloned().unwrap_or(Value::Null);
-                    calls.push(ProviderToolCall {
-                        tool_name: name.to_string(),
-                        arguments: normalize_command_run_tool_input(
-                            name,
-                            parse_arguments(arguments),
-                        ),
-                        provider_metadata: openai_tool_call_metadata(call),
-                    });
-                }
+            if let Some(function) = call.get("function")
+                && let Some(name) = function.get("name").and_then(Value::as_str)
+            {
+                let arguments = function.get("arguments").cloned().unwrap_or(Value::Null);
+                calls.push(ProviderToolCall {
+                    tool_name: name.to_string(),
+                    arguments: normalize_command_run_tool_input(name, parse_arguments(arguments)),
+                    provider_metadata: openai_tool_call_metadata(call),
+                });
             }
         }
     }
 
     if let Some(parts) = content.get("parts").and_then(Value::as_array) {
         for part in parts {
-            if let Some(function_call) = part.get("functionCall") {
-                if let Some(name) = function_call.get("name").and_then(Value::as_str) {
-                    calls.push(ProviderToolCall {
-                        tool_name: name.to_string(),
-                        arguments: normalize_command_run_tool_input(
-                            name,
-                            function_call.get("args").cloned().unwrap_or(Value::Null),
-                        ),
-                        provider_metadata: google_function_call_metadata(part),
-                    });
-                }
+            if let Some(function_call) = part.get("functionCall")
+                && let Some(name) = function_call.get("name").and_then(Value::as_str)
+            {
+                calls.push(ProviderToolCall {
+                    tool_name: name.to_string(),
+                    arguments: normalize_command_run_tool_input(
+                        name,
+                        function_call.get("args").cloned().unwrap_or(Value::Null),
+                    ),
+                    provider_metadata: google_function_call_metadata(part),
+                });
             }
         }
     }

--- a/crates/provider/src/tura_conf.rs
+++ b/crates/provider/src/tura_conf.rs
@@ -193,13 +193,27 @@ mod tests {
     impl EnvRestore {
         fn remove(key: &'static str) -> Self {
             let value = std::env::var_os(key);
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
             Self { key, value }
         }
 
         fn set(key: &'static str, value: &str) -> Self {
             let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
             Self {
                 key,
                 value: previous,
@@ -210,16 +224,37 @@ mod tests {
     impl Drop for EnvRestore {
         fn drop(&mut self) {
             if let Some(value) = &self.value {
-                std::env::set_var(self.key, value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(self.key, value)
+                };
             } else {
-                std::env::remove_var(self.key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(self.key)
+                };
             }
         }
     }
 
     #[test]
     fn get_reads_uppercase_environment_keys() {
-        std::env::set_var("TURA_CONF_TEST_KEY", "configured");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_CONF_TEST_KEY", "configured")
+        };
         let conf = TuraConfig::new(".env.missing-for-test");
 
         assert_eq!(
@@ -227,7 +262,14 @@ mod tests {
             Some("configured")
         );
 
-        std::env::remove_var("TURA_CONF_TEST_KEY");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_CONF_TEST_KEY")
+        };
     }
 
     #[test]

--- a/crates/provider/src/tura_llm.rs
+++ b/crates/provider/src/tura_llm.rs
@@ -502,7 +502,14 @@ fn openai_oauth_base_url_allowed(base_url: &str) -> bool {
 }
 
 async fn refresh_openai_access_token_if_needed(conf: &TuraConfig) -> Result<String, TuraError> {
-    std::env::set_var("OPENAI_LOGIN", "oauth");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_LOGIN", "oauth")
+    };
     let codex_auth = load_codex_auth_tokens();
     let access = conf
         .get("OPENAI_API_KEY")
@@ -567,8 +574,22 @@ async fn refresh_openai_access_token_if_needed(conf: &TuraConfig) -> Result<Stri
             if let Some(tokens) = codex_auth.as_ref() {
                 apply_codex_auth_env(tokens);
             } else {
-                std::env::set_var("OPENAI_API_KEY", &access);
-                std::env::set_var("OPENAI_REFRESH_TOKEN", &refresh);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("OPENAI_API_KEY", &access)
+                };
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("OPENAI_REFRESH_TOKEN", &refresh)
+                };
             }
             return Ok(access);
         }
@@ -586,14 +607,35 @@ async fn refresh_openai_access_token_if_needed(conf: &TuraConfig) -> Result<Stri
             message: "OpenAI OAuth refresh response did not include access_token".to_string(),
         })?
         .to_string();
-    std::env::set_var("OPENAI_API_KEY", &next_access);
-    if let Some(tokens) = codex_auth.as_ref() {
-        if let Some(account_id) = tokens.account_id.as_deref() {
-            std::env::set_var("OPENAI_ACCOUNT_ID", account_id);
-        }
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", &next_access)
+    };
+    if let Some(tokens) = codex_auth.as_ref()
+        && let Some(account_id) = tokens.account_id.as_deref()
+    {
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("OPENAI_ACCOUNT_ID", account_id)
+        };
     }
     if let Some(refresh) = body.get("refresh_token").and_then(Value::as_str) {
-        std::env::set_var("OPENAI_REFRESH_TOKEN", refresh);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("OPENAI_REFRESH_TOKEN", refresh)
+        };
     }
     let next_expires = now
         + body
@@ -601,7 +643,14 @@ async fn refresh_openai_access_token_if_needed(conf: &TuraConfig) -> Result<Stri
             .and_then(Value::as_i64)
             .unwrap_or(3600)
             * 1000;
-    std::env::set_var("OPENAI_TOKEN_EXPIRES", next_expires.to_string());
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_TOKEN_EXPIRES", next_expires.to_string())
+    };
     Ok(next_access)
 }
 
@@ -767,7 +816,14 @@ async fn try_refresh_oauth_access_token(
 
     let env_path = conf.env_path().to_path_buf();
     if let Some(token_env) = entry.token_env {
-        std::env::set_var(token_env, &access);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(token_env, &access)
+        };
         persist_env_var(&env_path, token_env, &access);
     }
     if let Some(new_refresh) = body
@@ -775,7 +831,14 @@ async fn try_refresh_oauth_access_token(
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty())
     {
-        std::env::set_var(refresh_env, new_refresh);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(refresh_env, new_refresh)
+        };
         persist_env_var(&env_path, refresh_env, new_refresh);
     }
     if let Some(expires_env) = entry.expires_env {
@@ -786,7 +849,14 @@ async fn try_refresh_oauth_access_token(
                 .unwrap_or(3600)
                 * 1000;
         let expires_at = expires_at.to_string();
-        std::env::set_var(expires_env, &expires_at);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(expires_env, &expires_at)
+        };
         persist_env_var(&env_path, expires_env, &expires_at);
     }
 
@@ -872,11 +942,39 @@ fn codex_auth_json_path() -> Option<PathBuf> {
 }
 
 fn apply_codex_auth_env(tokens: &CodexAuthTokens) {
-    std::env::set_var("OPENAI_LOGIN", "oauth");
-    std::env::set_var("OPENAI_API_KEY", &tokens.access_token);
-    std::env::set_var("OPENAI_REFRESH_TOKEN", &tokens.refresh_token);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_LOGIN", "oauth")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", &tokens.access_token)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_REFRESH_TOKEN", &tokens.refresh_token)
+    };
     if let Some(account_id) = tokens.account_id.as_deref() {
-        std::env::set_var("OPENAI_ACCOUNT_ID", account_id);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("OPENAI_ACCOUNT_ID", account_id)
+        };
     }
 }
 
@@ -934,10 +1032,10 @@ pub fn default_client(api_key: &str) -> Result<reqwest::Client, TuraError> {
 }
 
 pub fn normalize_response_content(raw: &Value) -> Value {
-    if raw.get("events").and_then(Value::as_array).is_some() {
-        if let Some(content) = crate::llm::openapi::normalize_codex_response_event_content(raw) {
-            return content;
-        }
+    if raw.get("events").and_then(Value::as_array).is_some()
+        && let Some(content) = crate::llm::openapi::normalize_codex_response_event_content(raw)
+    {
+        return content;
     }
     if let Some(message) = raw.pointer("/choices/0/message") {
         let content = message.get("content").cloned().unwrap_or(Value::Null);

--- a/crates/provider/src/tura_llm_conf.rs
+++ b/crates/provider/src/tura_llm_conf.rs
@@ -49,7 +49,14 @@ mod tests {
     fn config_path_prefers_explicit_provider_config() {
         let _guard = crate::test_support::env_lock();
         let previous_provider = std::env::var_os("TURA_PROVIDER_CONFIG");
-        std::env::set_var("TURA_PROVIDER_CONFIG", "C:/tmp/tura-test-config.json");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROVIDER_CONFIG", "C:/tmp/tura-test-config.json")
+        };
 
         assert_eq!(
             config_path(),
@@ -57,8 +64,26 @@ mod tests {
         );
 
         match previous_provider {
-            Some(value) => std::env::set_var("TURA_PROVIDER_CONFIG", value),
-            None => std::env::remove_var("TURA_PROVIDER_CONFIG"),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("TURA_PROVIDER_CONFIG", value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var("TURA_PROVIDER_CONFIG")
+                }
+            }
         }
     }
 
@@ -66,7 +91,14 @@ mod tests {
     async fn bundled_config_exposes_four_model_tiers() {
         let _guard = crate::test_support::env_lock_async().await;
         let previous_provider = std::env::var_os("TURA_PROVIDER_CONFIG");
-        std::env::remove_var("TURA_PROVIDER_CONFIG");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_PROVIDER_CONFIG")
+        };
 
         let settings = super::load_settings().await.expect("load bundled config");
         for route in ["thinking", "fast", "embedding_high", "embedding_low"] {
@@ -89,8 +121,26 @@ mod tests {
         );
 
         match previous_provider {
-            Some(value) => std::env::set_var("TURA_PROVIDER_CONFIG", value),
-            None => std::env::remove_var("TURA_PROVIDER_CONFIG"),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("TURA_PROVIDER_CONFIG", value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var("TURA_PROVIDER_CONFIG")
+                }
+            }
         }
     }
 }

--- a/crates/provider/src/tura_llm_config.rs
+++ b/crates/provider/src/tura_llm_config.rs
@@ -493,10 +493,8 @@ pub struct RawProviderConfig {
 impl Settings {
     pub async fn default() -> Result<Arc<Self>, TuraError> {
         let explicit_config = std::env::var_os("TURA_PROVIDER_CONFIG").is_some();
-        if !explicit_config {
-            if let Some(settings) = SETTINGS.get() {
-                return Ok(Arc::clone(settings));
-            }
+        if !explicit_config && let Some(settings) = SETTINGS.get() {
+            return Ok(Arc::clone(settings));
         }
         let loaded = Arc::new(crate::tura_llm_conf::load_settings().await?);
         if !explicit_config {

--- a/crates/provider/src/tura_llm_tests.rs
+++ b/crates/provider/src/tura_llm_tests.rs
@@ -26,9 +26,23 @@ impl Drop for EnvRestore {
     fn drop(&mut self) {
         for (key, value) in &self.keys {
             if let Some(value) = value {
-                std::env::set_var(key, value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(key, value)
+                };
             } else {
-                std::env::remove_var(key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(key)
+                };
             }
         }
     }
@@ -211,11 +225,46 @@ fn loads_codex_oauth_tokens_from_codex_home() {
         "OPENAI_ACCOUNT_ID",
         "TURA_PROVIDER_CONFIG",
     ]);
-    std::env::remove_var("OPENAI_LOGIN");
-    std::env::remove_var("OPENAI_API_KEY");
-    std::env::remove_var("OPENAI_REFRESH_TOKEN");
-    std::env::remove_var("OPENAI_ACCOUNT_ID");
-    std::env::remove_var("TURA_PROVIDER_CONFIG");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("OPENAI_LOGIN")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("OPENAI_API_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("OPENAI_REFRESH_TOKEN")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("OPENAI_ACCOUNT_ID")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_PROVIDER_CONFIG")
+    };
 
     let codex_home = unique_temp_dir("codex-home");
     std::fs::write(
@@ -231,7 +280,14 @@ fn loads_codex_oauth_tokens_from_codex_home() {
             }"#,
     )
     .expect("auth json");
-    std::env::set_var("CODEX_HOME", &codex_home);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("CODEX_HOME", &codex_home)
+    };
 
     let tokens = load_codex_auth_tokens().expect("codex auth tokens");
     apply_codex_auth_env(&tokens);
@@ -292,8 +348,22 @@ async fn prefers_codex_auth_when_env_token_is_still_marked_valid() {
     )
     .expect("write tura env");
 
-    std::env::set_var("CODEX_HOME", &codex_home);
-    std::env::set_var("TURA_ENV_PATH", &env_path);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("CODEX_HOME", &codex_home)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_ENV_PATH", &env_path)
+    };
     for key in [
         "OPENAI_LOGIN",
         "OPENAI_API_KEY",
@@ -301,7 +371,14 @@ async fn prefers_codex_auth_when_env_token_is_still_marked_valid() {
         "OPENAI_TOKEN_EXPIRES",
         "OPENAI_ACCOUNT_ID",
     ] {
-        std::env::remove_var(key);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(key)
+        };
     }
     let conf = crate::TuraConfig::new(".env.missing");
 
@@ -334,16 +411,51 @@ fn openai_oauth_login_uses_provider_auth_config() {
         "OPENAI_API_KEY",
         "TURA_PROVIDER_CONFIG",
     ]);
-    std::env::remove_var("CODEX_HOME");
-    std::env::remove_var("OPENAI_LOGIN");
-    std::env::remove_var("OPENAI_API_KEY");
-    std::env::remove_var("TURA_PROVIDER_CONFIG");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("CODEX_HOME")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("OPENAI_LOGIN")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("OPENAI_API_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_PROVIDER_CONFIG")
+    };
 
     let dir = unique_temp_dir("provider-config");
     let config = dir.join("provider_config.json");
     std::fs::write(&config, r#"{"provider_auth":{"openai":{"login":"oauth"}}}"#)
         .expect("provider config");
-    std::env::set_var("TURA_PROVIDER_CONFIG", &config);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_PROVIDER_CONFIG", &config)
+    };
 
     assert!(openai_login_is_oauth(
         &crate::tura_conf::TuraConfig::default()

--- a/crates/provider/src/utils/command_run_arguments.rs
+++ b/crates/provider/src/utils/command_run_arguments.rs
@@ -30,13 +30,12 @@ fn normalize_command_run_input(input: Value) -> Value {
                         .map(normalize_command_value)
                         .collect()
                 } else if contains_command_shape(&object) {
-                    if !object.contains_key("command_line") {
-                        if let Some(command_line) =
+                    if !object.contains_key("command_line")
+                        && let Some(command_line) =
                             partial_xml_parameter_value(&text, "command_line")
                                 .or_else(|| partial_xml_parameter_value(&text, "cmd"))
-                        {
-                            object.insert("command_line".to_string(), Value::String(command_line));
-                        }
+                    {
+                        object.insert("command_line".to_string(), Value::String(command_line));
                     }
                     return json!({ "commands": [normalize_command_value(Value::Object(object))] });
                 } else {

--- a/crates/provider/src/utils/command_run_stream_events.rs
+++ b/crates/provider/src/utils/command_run_stream_events.rs
@@ -59,12 +59,11 @@ fn command_run_commands_from_arguments(arguments: &Value) -> Option<Vec<Value>> 
     if let Some(commands) = arguments.get("commands").and_then(Value::as_array) {
         return Some(commands.clone());
     }
-    if let Some(text) = arguments.as_str() {
-        if let Ok(parsed) = serde_json::from_str::<Value>(text) {
-            if let Some(commands) = parsed.get("commands").and_then(Value::as_array) {
-                return Some(commands.clone());
-            }
-        }
+    if let Some(text) = arguments.as_str()
+        && let Ok(parsed) = serde_json::from_str::<Value>(text)
+        && let Some(commands) = parsed.get("commands").and_then(Value::as_array)
+    {
+        return Some(commands.clone());
     }
     None
 }

--- a/crates/provider/tests/live/google_local_flow.rs
+++ b/crates/provider/tests/live/google_local_flow.rs
@@ -69,7 +69,14 @@ async fn google_business_flow_generates_content_with_tools_system_usage_and_requ
     });
 
     let previous_key = std::env::var_os("GOOGLE_API_KEY");
-    std::env::set_var("GOOGLE_API_KEY", "dummy-google-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("GOOGLE_API_KEY", "dummy-google-key")
+    };
     let config = ProviderConfig {
         provider: "google".to_string(),
         base_url: format!("http://{addr}/v1beta"),
@@ -130,8 +137,26 @@ async fn google_business_flow_generates_content_with_tools_system_usage_and_requ
         .await;
 
     match previous_key {
-        Some(value) => std::env::set_var("GOOGLE_API_KEY", value),
-        None => std::env::remove_var("GOOGLE_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("GOOGLE_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("GOOGLE_API_KEY")
+            }
+        }
     }
 
     let response = result.expect("local google provider call");
@@ -257,7 +282,14 @@ async fn google_business_flow_replays_function_call_output_and_media_sidecar() {
     });
 
     let previous_key = std::env::var_os("GOOGLE_API_KEY");
-    std::env::set_var("GOOGLE_API_KEY", "dummy-google-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("GOOGLE_API_KEY", "dummy-google-key")
+    };
     let config = ProviderConfig {
         provider: "google".to_string(),
         base_url: format!("http://{addr}"),
@@ -290,8 +322,26 @@ async fn google_business_flow_replays_function_call_output_and_media_sidecar() {
         .await;
 
     match previous_key {
-        Some(value) => std::env::set_var("GOOGLE_API_KEY", value),
-        None => std::env::remove_var("GOOGLE_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("GOOGLE_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("GOOGLE_API_KEY")
+            }
+        }
     }
 
     let response = result.expect("local google replay call");
@@ -360,7 +410,14 @@ async fn google_business_flow_embeds_local_vectors_and_rejects_missing_values() 
     });
 
     let previous_key = std::env::var_os("GOOGLE_API_KEY");
-    std::env::set_var("GOOGLE_API_KEY", "dummy-google-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("GOOGLE_API_KEY", "dummy-google-key")
+    };
     let config = ProviderConfig {
         provider: "google".to_string(),
         base_url: format!("http://{addr}"),
@@ -423,8 +480,26 @@ async fn google_business_flow_embeds_local_vectors_and_rejects_missing_values() 
     let bad_captured = bad_server.join().expect("bad google embed server joins");
 
     match previous_key {
-        Some(value) => std::env::set_var("GOOGLE_API_KEY", value),
-        None => std::env::remove_var("GOOGLE_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("GOOGLE_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("GOOGLE_API_KEY")
+            }
+        }
     }
 
     assert_eq!(
@@ -468,7 +543,14 @@ async fn google_business_flow_reports_http_status_body_and_invalid_json() {
     });
 
     let previous_key = std::env::var_os("GOOGLE_API_KEY");
-    std::env::set_var("GOOGLE_API_KEY", "dummy-google-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("GOOGLE_API_KEY", "dummy-google-key")
+    };
     let config = ProviderConfig {
         provider: "google".to_string(),
         base_url: format!("http://{addr}"),
@@ -531,8 +613,26 @@ async fn google_business_flow_reports_http_status_body_and_invalid_json() {
     let invalid_captured = invalid_server.join().expect("invalid google server joins");
 
     match previous_key {
-        Some(value) => std::env::set_var("GOOGLE_API_KEY", value),
-        None => std::env::remove_var("GOOGLE_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("GOOGLE_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("GOOGLE_API_KEY")
+            }
+        }
     }
 
     assert_eq!(

--- a/crates/provider/tests/live/openai_compatible_local/codex_auth.rs
+++ b/crates/provider/tests/live/openai_compatible_local/codex_auth.rs
@@ -16,9 +16,23 @@ impl Drop for EnvRestore {
     fn drop(&mut self) {
         for (key, value) in self.0.drain(..) {
             if let Some(value) = value {
-                std::env::set_var(key, value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(key, value)
+                };
             } else {
-                std::env::remove_var(key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(key)
+                };
             }
         }
     }
@@ -89,9 +103,30 @@ async fn codex_oauth_uses_rotated_local_auth_across_two_calls() {
         requests
     });
 
-    std::env::set_var("CODEX_HOME", &codex_home);
-    std::env::set_var("TURA_ENV_PATH", &env_path);
-    std::env::set_var("OPENAI_CODEX_ENDPOINT", &endpoint);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("CODEX_HOME", &codex_home)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_ENV_PATH", &env_path)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("OPENAI_CODEX_ENDPOINT", &endpoint)
+    };
     for key in [
         "OPENAI_LOGIN",
         "OPENAI_API_KEY",
@@ -99,7 +134,14 @@ async fn codex_oauth_uses_rotated_local_auth_across_two_calls() {
         "OPENAI_TOKEN_EXPIRES",
         "OPENAI_ACCOUNT_ID",
     ] {
-        std::env::remove_var(key);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(key)
+        };
     }
 
     let config = TuraConfig::new(".env.missing");

--- a/crates/provider/tests/live/openai_compatible_local/content_variants.rs
+++ b/crates/provider/tests/live/openai_compatible_local/content_variants.rs
@@ -174,7 +174,14 @@ fn openai_compatible_provider_boundary_business_flow_normalizes_runtime_visible_
     assert_eq!(passthrough["query"], "docs");
 
     let previous_prompt_cache = std::env::var_os("TURA_DISABLE_PROMPT_CACHE");
-    std::env::remove_var("TURA_DISABLE_PROMPT_CACHE");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_DISABLE_PROMPT_CACHE")
+    };
     assert!(prompt_cache_key_supported(
         "openai",
         "https://api.openai.com/v1"
@@ -199,14 +206,39 @@ fn openai_compatible_provider_boundary_business_flow_normalizes_runtime_visible_
         "localtest",
         "https://example.invalid/v1"
     ));
-    std::env::set_var("TURA_DISABLE_PROMPT_CACHE", "true");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_DISABLE_PROMPT_CACHE", "true")
+    };
     assert!(!prompt_cache_key_supported(
         "openai",
         "https://api.openai.com/v1"
     ));
     match previous_prompt_cache {
-        Some(value) => std::env::set_var("TURA_DISABLE_PROMPT_CACHE", value),
-        None => std::env::remove_var("TURA_DISABLE_PROMPT_CACHE"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_DISABLE_PROMPT_CACHE", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("TURA_DISABLE_PROMPT_CACHE")
+            }
+        }
     }
 
     assert!(openai_compatible_usage_stream_supported(
@@ -288,7 +320,14 @@ async fn openai_compatible_business_flow_normalizes_content_parts_tools_costs_an
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -312,8 +351,26 @@ async fn openai_compatible_business_flow_normalizes_content_parts_tools_costs_an
         .expect("content-part provider call should succeed");
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let captured = server.join().expect("server thread joins");

--- a/crates/provider/tests/live/openai_compatible_local/core_tooling.rs
+++ b/crates/provider/tests/live/openai_compatible_local/core_tooling.rs
@@ -51,8 +51,9 @@ async fn openai_compatible_business_flow_streams_local_tool_response_and_metrics
                 "prompt_tokens_details": {"cached_tokens": 7}
             }
         });
-        let body =
-            format!("data: {first}\n\ndata: {tool_start}\n\ndata: {tool_end}\n\ndata: {usage}\n\ndata: [DONE]\n\n");
+        let body = format!(
+            "data: {first}\n\ndata: {tool_start}\n\ndata: {tool_end}\n\ndata: {usage}\n\ndata: [DONE]\n\n"
+        );
         let response = format!(
             "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\n\r\n{}",
             body.len(),
@@ -65,7 +66,14 @@ async fn openai_compatible_business_flow_streams_local_tool_response_and_metrics
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -104,8 +112,26 @@ async fn openai_compatible_business_flow_streams_local_tool_response_and_metrics
         .await;
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let response = result.expect("local provider call");
@@ -154,7 +180,14 @@ async fn openai_compatible_business_flow_streams_local_tool_response_and_metrics
 async fn openai_compatible_business_flow_reports_missing_local_key_without_network() {
     let _env_guard = ENV_LOCK.lock().await;
     let previous_key = std::env::var_os("LOCALTEST_MISSING_API_KEY");
-    std::env::remove_var("LOCALTEST_MISSING_API_KEY");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("LOCALTEST_MISSING_API_KEY")
+    };
     let config = ProviderConfig {
         provider: "localtest_missing".to_string(),
         base_url: "http://127.0.0.1:9".to_string(),
@@ -172,8 +205,26 @@ async fn openai_compatible_business_flow_reports_missing_local_key_without_netwo
         .expect_err("missing key should fail before any network call");
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_MISSING_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_MISSING_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_MISSING_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_MISSING_API_KEY")
+            }
+        }
     }
 
     match err {
@@ -216,7 +267,14 @@ async fn openai_compatible_business_flow_embeds_local_vectors_and_rejects_bad_pa
     });
 
     let previous_key = std::env::var_os("LOCALEMBED_API_KEY");
-    std::env::set_var("LOCALEMBED_API_KEY", "dummy-embed-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALEMBED_API_KEY", "dummy-embed-key")
+    };
     let config = ProviderConfig {
         provider: "localembed".to_string(),
         base_url: format!("http://{addr}"),
@@ -286,8 +344,26 @@ async fn openai_compatible_business_flow_embeds_local_vectors_and_rejects_bad_pa
         .expect("bad embedding server thread joins");
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALEMBED_API_KEY", value),
-        None => std::env::remove_var("LOCALEMBED_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALEMBED_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALEMBED_API_KEY")
+            }
+        }
     }
 
     assert_eq!(bad_captured.path, "/embeddings");
@@ -336,7 +412,14 @@ async fn openai_compatible_business_flow_preserves_native_tool_conversation_shap
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -381,8 +464,26 @@ async fn openai_compatible_business_flow_preserves_native_tool_conversation_shap
         .await;
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let response = result.expect("local provider call");
@@ -457,7 +558,14 @@ async fn openai_compatible_business_flow_non_stream_tool_calls_extract_structure
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -484,8 +592,26 @@ async fn openai_compatible_business_flow_non_stream_tool_calls_extract_structure
         .await;
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let response = result.expect("local non-stream tool call");
@@ -564,7 +690,14 @@ async fn openai_compatible_business_flow_forwards_documented_request_options_and
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -615,8 +748,26 @@ async fn openai_compatible_business_flow_forwards_documented_request_options_and
         .await;
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let response = result.expect("local provider call");
@@ -751,8 +902,22 @@ async fn openai_compatible_business_flow_writes_success_and_error_logs_to_config
     let log_root = tempfile::tempdir().expect("provider log root");
     let previous_log_path = std::env::var_os("LOG_PATH");
     let previous_key = std::env::var_os("LOCALLOG_API_KEY");
-    std::env::set_var("LOG_PATH", log_root.path());
-    std::env::set_var("LOCALLOG_API_KEY", "dummy-log-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOG_PATH", log_root.path())
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALLOG_API_KEY", "dummy-log-key")
+    };
 
     let success_config = ProviderConfig {
         provider: "locallog".to_string(),
@@ -800,12 +965,48 @@ async fn openai_compatible_business_flow_writes_success_and_error_logs_to_config
         .expect_err("error log provider call should fail");
 
     match previous_log_path {
-        Some(value) => std::env::set_var("LOG_PATH", value),
-        None => std::env::remove_var("LOG_PATH"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOG_PATH", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOG_PATH")
+            }
+        }
     }
     match previous_key {
-        Some(value) => std::env::set_var("LOCALLOG_API_KEY", value),
-        None => std::env::remove_var("LOCALLOG_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALLOG_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALLOG_API_KEY")
+            }
+        }
     }
 
     let success_request = success_server.join().expect("success log server joins");

--- a/crates/provider/tests/live/openai_compatible_local/error_variants.rs
+++ b/crates/provider/tests/live/openai_compatible_local/error_variants.rs
@@ -32,7 +32,14 @@ async fn openai_compatible_business_flow_rejects_empty_success_shapes_without_si
         });
 
         let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+        };
         let config = ProviderConfig {
             provider: "localtest".to_string(),
             base_url: format!("http://{addr}"),
@@ -49,8 +56,26 @@ async fn openai_compatible_business_flow_rejects_empty_success_shapes_without_si
             .expect_err("empty provider success shapes should be rejected");
 
         match previous_key {
-            Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-            None => std::env::remove_var("LOCALTEST_API_KEY"),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("LOCALTEST_API_KEY", value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var("LOCALTEST_API_KEY")
+                }
+            }
         }
 
         let captured = server.join().expect("server thread joins");
@@ -109,7 +134,14 @@ async fn openai_compatible_business_flow_reports_provider_http_status_and_body()
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -126,8 +158,26 @@ async fn openai_compatible_business_flow_reports_provider_http_status_and_body()
         .expect_err("provider HTTP error should fail the call");
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let captured = server.join().expect("server thread joins");
@@ -167,7 +217,14 @@ async fn openai_compatible_business_flow_reports_invalid_json_response() {
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -184,8 +241,26 @@ async fn openai_compatible_business_flow_reports_invalid_json_response() {
         .expect_err("invalid provider JSON should fail the call");
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let captured = server.join().expect("server thread joins");
@@ -223,7 +298,14 @@ async fn openai_compatible_business_flow_reports_invalid_stream_event_json() {
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -244,8 +326,26 @@ async fn openai_compatible_business_flow_reports_invalid_stream_event_json() {
         .expect_err("invalid stream JSON should fail the call");
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let captured = server.join().expect("server thread joins");
@@ -285,7 +385,14 @@ async fn openai_compatible_business_flow_reports_truncated_stream_transport_erro
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -313,8 +420,26 @@ async fn openai_compatible_business_flow_reports_truncated_stream_transport_erro
         .expect_err("truncated provider stream must fail the call");
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let captured = server.join().expect("server thread joins");
@@ -370,7 +495,14 @@ async fn openai_compatible_business_flow_rejects_empty_stream_success_without_si
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -392,8 +524,26 @@ async fn openai_compatible_business_flow_rejects_empty_stream_success_without_si
         .expect_err("empty stream success must not become a null assistant turn");
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let captured = server.join().expect("server thread joins");
@@ -445,7 +595,14 @@ async fn openai_compatible_business_flow_preserves_reasoning_only_stream_as_cont
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let config = ProviderConfig {
         provider: "localtest".to_string(),
         base_url: format!("http://{addr}"),
@@ -473,8 +630,26 @@ async fn openai_compatible_business_flow_preserves_reasoning_only_stream_as_cont
         .await;
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let response = result.expect("reasoning-only stream should produce content");

--- a/crates/provider/tests/live/openai_compatible_local/routing_failover.rs
+++ b/crates/provider/tests/live/openai_compatible_local/routing_failover.rs
@@ -48,7 +48,14 @@ async fn openai_compatible_business_flow_concurrent_calls_keep_request_and_respo
     });
 
     let previous_key = std::env::var_os("LOCALCONCURRENT_API_KEY");
-    std::env::set_var("LOCALCONCURRENT_API_KEY", "dummy-concurrent-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALCONCURRENT_API_KEY", "dummy-concurrent-key")
+    };
     let config = ProviderConfig {
         provider: "localconcurrent".to_string(),
         base_url: format!("http://{addr}"),
@@ -82,8 +89,26 @@ async fn openai_compatible_business_flow_concurrent_calls_keep_request_and_respo
     );
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALCONCURRENT_API_KEY", value),
-        None => std::env::remove_var("LOCALCONCURRENT_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALCONCURRENT_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALCONCURRENT_API_KEY")
+            }
+        }
     }
 
     let alpha = alpha.expect("alpha concurrent provider call");
@@ -197,7 +222,14 @@ async fn openai_compatible_route_business_flow_falls_back_after_provider_error()
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let route = RouteConfig {
         default_temperature: 0.55,
         providers: vec![
@@ -232,8 +264,26 @@ async fn openai_compatible_route_business_flow_falls_back_after_provider_error()
         .await;
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let response = result.expect("route should fall back to the second local provider");
@@ -322,7 +372,14 @@ async fn openai_compatible_route_business_flow_uses_first_healthy_provider_witho
         thread::spawn(move || accept_optional_provider_request(fallback_listener, 400));
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let route = RouteConfig {
         default_temperature: 0.42,
         providers: vec![
@@ -357,8 +414,26 @@ async fn openai_compatible_route_business_flow_uses_first_healthy_provider_witho
         .await;
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let response = result.expect("route should use first healthy local provider");
@@ -450,7 +525,14 @@ async fn openai_compatible_route_business_flow_reports_all_provider_failures_wit
     });
 
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-local-key")
+    };
     let route = RouteConfig {
         default_temperature: 0.25,
         providers: vec![
@@ -486,8 +568,26 @@ async fn openai_compatible_route_business_flow_reports_all_provider_failures_wit
         .expect_err("all failing route providers should surface aggregate failure");
 
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let first = http_error_server.join().expect("http-error server joins");

--- a/crates/provider/tests/live/openai_compatible_local/settings_catalog.rs
+++ b/crates/provider/tests/live/openai_compatible_local/settings_catalog.rs
@@ -63,8 +63,22 @@ async fn openai_compatible_route_business_flow_loads_named_route_from_provider_c
 
     let previous_config = std::env::var_os("TURA_PROVIDER_CONFIG");
     let previous_key = std::env::var_os("LOCALTEST_API_KEY");
-    std::env::set_var("TURA_PROVIDER_CONFIG", &config_path);
-    std::env::set_var("LOCALTEST_API_KEY", "dummy-configured-key");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_PROVIDER_CONFIG", &config_path)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("LOCALTEST_API_KEY", "dummy-configured-key")
+    };
 
     let settings = Settings::default()
         .await
@@ -89,12 +103,48 @@ async fn openai_compatible_route_business_flow_loads_named_route_from_provider_c
         .await;
 
     match previous_config {
-        Some(value) => std::env::set_var("TURA_PROVIDER_CONFIG", value),
-        None => std::env::remove_var("TURA_PROVIDER_CONFIG"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_PROVIDER_CONFIG", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("TURA_PROVIDER_CONFIG")
+            }
+        }
     }
     match previous_key {
-        Some(value) => std::env::set_var("LOCALTEST_API_KEY", value),
-        None => std::env::remove_var("LOCALTEST_API_KEY"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("LOCALTEST_API_KEY", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("LOCALTEST_API_KEY")
+            }
+        }
     }
 
     let response = result.expect("configured route should call local provider");
@@ -262,15 +312,40 @@ async fn openai_compatible_settings_business_flow_loads_explicit_config_catalog_
     .expect("write preferred provider config");
 
     let previous_provider_config = std::env::var_os("TURA_PROVIDER_CONFIG");
-    std::env::set_var("TURA_PROVIDER_CONFIG", &preferred_config);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_PROVIDER_CONFIG", &preferred_config)
+    };
 
     let settings = Settings::default()
         .await
         .expect("explicit provider config should load");
 
     match previous_provider_config {
-        Some(value) => std::env::set_var("TURA_PROVIDER_CONFIG", value),
-        None => std::env::remove_var("TURA_PROVIDER_CONFIG"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_PROVIDER_CONFIG", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("TURA_PROVIDER_CONFIG")
+            }
+        }
     }
 
     assert_eq!(settings.routes.len(), 2);
@@ -397,15 +472,40 @@ async fn openai_compatible_settings_business_flow_rejects_route_provider_missing
     .expect("write bad provider config");
 
     let previous_provider_config = std::env::var_os("TURA_PROVIDER_CONFIG");
-    std::env::set_var("TURA_PROVIDER_CONFIG", &config_path);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_PROVIDER_CONFIG", &config_path)
+    };
 
     let err = Settings::default()
         .await
         .expect_err("missing provider base URL should fail route construction");
 
     match previous_provider_config {
-        Some(value) => std::env::set_var("TURA_PROVIDER_CONFIG", value),
-        None => std::env::remove_var("TURA_PROVIDER_CONFIG"),
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        Some(value) => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_PROVIDER_CONFIG", value)
+            }
+        }
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        None => {
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("TURA_PROVIDER_CONFIG")
+            }
+        }
     }
 
     match err {

--- a/crates/router/src/daemon.rs
+++ b/crates/router/src/daemon.rs
@@ -95,7 +95,14 @@ pub(crate) async fn serve_socket() -> anyhow::Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
     publish_router_addr(&addr)?;
-    std::env::set_var("TURA_ROUTER_ADDR", addr.to_string());
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_ROUTER_ADDR", addr.to_string())
+    };
     eprintln!("router socket daemon listening on {addr}");
     start_idle_shutdown_monitor(state.clone());
 

--- a/crates/router/src/registry.rs
+++ b/crates/router/src/registry.rs
@@ -63,10 +63,10 @@ fn binary_target_candidates(repo_root: &Path, file_name: &str) -> Vec<PathBuf> {
     if let Some(release_bin_dir) = std::env::var_os("TURA_RELEASE_BIN_DIR") {
         candidates.push(PathBuf::from(release_bin_dir).join(file_name));
     }
-    if let Ok(current_exe) = std::env::current_exe() {
-        if let Some(directory) = current_exe.parent() {
-            candidates.push(directory.join(file_name));
-        }
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(directory) = current_exe.parent()
+    {
+        candidates.push(directory.join(file_name));
     }
     candidates.push(repo_root.join("bin").join(file_name));
     candidates.push(repo_root.join("target").join("debug").join(file_name));
@@ -86,7 +86,14 @@ mod tests {
     impl EnvGuard {
         fn set(key: &'static str, value: &std::path::Path) -> Self {
             let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
             Self { key, previous }
         }
     }
@@ -94,8 +101,26 @@ mod tests {
     impl Drop for EnvGuard {
         fn drop(&mut self) {
             match self.previous.take() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(self.key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(self.key)
+                    }
+                }
             }
         }
     }

--- a/crates/router/src/registry/agent.rs
+++ b/crates/router/src/registry/agent.rs
@@ -173,10 +173,10 @@ impl AgentRegistry {
 
     /// Resolve by explicit agent first, then fall back to session type.
     pub fn resolve(&self, agent: Option<&str>, session_type: Option<&str>) -> AgentSpec {
-        if let Some(agent) = agent {
-            if let Some(spec) = self.resolve_by_name(agent) {
-                return spec;
-            }
+        if let Some(agent) = agent
+            && let Some(spec) = self.resolve_by_name(agent)
+        {
+            return spec;
         }
         self.resolve_by_session_type(session_type.unwrap_or("general"))
     }

--- a/crates/router/src/registry/command.rs
+++ b/crates/router/src/registry/command.rs
@@ -19,7 +19,9 @@ impl CommandRegistry {
             .into_iter()
             .find(|command| command.name == command_name);
         let output = match command.and_then(|command| command.template) {
-            Some(template) => render_command_template(&template, payload.args.as_deref().unwrap_or_default()),
+            Some(template) => {
+                render_command_template(&template, payload.args.as_deref().unwrap_or_default())
+            }
             None => format!(
                 "Command `{command_name}` is not configured. Add a markdown or JSON command under .tura/commands, .opencode/command, .opencode/commands, command, or commands."
             ),
@@ -36,10 +38,10 @@ fn discover_commands(directory: Option<&str>) -> Vec<CommandSpec> {
         };
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.is_file() {
-                if let Some(command) = command_from_file(&path) {
-                    commands.push(command);
-                }
+            if path.is_file()
+                && let Some(command) = command_from_file(&path)
+            {
+                commands.push(command);
             }
         }
     }

--- a/crates/router/src/runtime_dispatch.rs
+++ b/crates/router/src/runtime_dispatch.rs
@@ -179,10 +179,10 @@ async fn dispatch_run_agent_inner(
         env.push((key.clone(), value.clone()));
     }
     push_router_owned_runtime_env(&mut env);
-    if let Ok(addr) = std::env::var("TURA_ROUTER_ADDR") {
-        if !addr.trim().is_empty() {
-            env.push(("TURA_ROUTER_ADDR".to_string(), addr));
-        }
+    if let Ok(addr) = std::env::var("TURA_ROUTER_ADDR")
+        && !addr.trim().is_empty()
+    {
+        env.push(("TURA_ROUTER_ADDR".to_string(), addr));
     }
 
     let spec = WorkerSpec {
@@ -238,7 +238,9 @@ async fn dispatch_run_agent_inner(
     let worker_id = worker.worker_id.clone();
     let worker_cleanup = RuntimeWorkerCleanupGuard::new(state.manager.clone(), worker_id.clone());
     if router_debug_enabled() {
-        eprintln!("router debug: dispatch_run_agent calling worker session_id={session_id} worker_id={worker_id}");
+        eprintln!(
+            "router debug: dispatch_run_agent calling worker session_id={session_id} worker_id={worker_id}"
+        );
     }
     let call_result = state.manager.call_worker(&worker_id, ctx).await;
     worker_cleanup.stop_now().await;

--- a/crates/router/src/services/process_scope.rs
+++ b/crates/router/src/services/process_scope.rs
@@ -177,12 +177,12 @@ const SIGTERM: i32 = 15;
 const PR_SET_PDEATHSIG: i32 = 1;
 
 #[cfg(unix)]
-extern "C" {
+unsafe extern "C" {
     fn kill(pid: i32, sig: i32) -> i32;
 }
 
 #[cfg(target_os = "linux")]
-extern "C" {
+unsafe extern "C" {
     fn prctl(option: i32, arg2: usize, arg3: usize, arg4: usize, arg5: usize) -> i32;
     fn getppid() -> i32;
 }

--- a/crates/router/src/services/runtime_orphans.rs
+++ b/crates/router/src/services/runtime_orphans.rs
@@ -93,10 +93,10 @@ pub fn runtime_worker_orphan_decision(
         let Some(parent) = system.process(Pid::from_u32(parent_pid)) else {
             return RuntimeWorkerOrphanDecision::Kill;
         };
-        if let Some(expected_start) = env_u64(&process.environ, "TURA_ROUTER_PARENT_START_TIME") {
-            if parent.start_time() != expected_start {
-                return RuntimeWorkerOrphanDecision::Kill;
-            }
+        if let Some(expected_start) = env_u64(&process.environ, "TURA_ROUTER_PARENT_START_TIME")
+            && parent.start_time() != expected_start
+        {
+            return RuntimeWorkerOrphanDecision::Kill;
         }
         return RuntimeWorkerOrphanDecision::Keep;
     }

--- a/crates/router/src/services/session_db.rs
+++ b/crates/router/src/services/session_db.rs
@@ -122,11 +122,11 @@ impl SessionDbService {
         if service_is_running() {
             let _ = call_service(&session_log_contract::SessionLogCommand::Shutdown);
         }
-        if let Some(mut child) = child {
-            if !wait_for_child_exit(&mut child, std::time::Duration::from_secs(10)) {
-                let _ = child.kill();
-                let _ = child.wait();
-            }
+        if let Some(mut child) = child
+            && !wait_for_child_exit(&mut child, std::time::Duration::from_secs(10))
+        {
+            let _ = child.kill();
+            let _ = child.wait();
         }
         let _ = std::fs::remove_file(service_addr_path());
     }
@@ -167,16 +167,16 @@ impl SessionDbService {
                     .child
                     .lock()
                     .map_err(|_| anyhow!("session_db lock poisoned"))?;
-                if let Some(child) = guard.as_mut() {
-                    if let Some(status) = child.try_wait()? {
-                        *guard = None;
-                        let detail = unreachable_owner_lock_message()
-                            .map(|message| format!("; {message}"))
-                            .unwrap_or_default();
-                        return Err(anyhow!(
+                if let Some(child) = guard.as_mut()
+                    && let Some(status) = child.try_wait()?
+                {
+                    *guard = None;
+                    let detail = unreachable_owner_lock_message()
+                        .map(|message| format!("; {message}"))
+                        .unwrap_or_default();
+                    return Err(anyhow!(
                             "session_db service exited before publishing a reachable socket: {status}{detail}"
                         ));
-                    }
                 }
             }
             if started.elapsed() >= timeout {
@@ -438,10 +438,38 @@ mod tests {
                 .iter()
                 .map(|key| (*key, std::env::var_os(key)))
                 .collect::<Vec<_>>();
-            std::env::set_var("TURA_HOME", home);
-            std::env::remove_var("SESSION_LOG_DB_ROOT");
-            std::env::remove_var("TURA_DB_ROOT");
-            std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "25");
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_HOME", home)
+            };
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("SESSION_LOG_DB_ROOT")
+            };
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("TURA_DB_ROOT")
+            };
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "25")
+            };
             Self { previous }
         }
     }
@@ -450,8 +478,26 @@ mod tests {
         fn drop(&mut self) {
             for (key, value) in self.previous.drain(..) {
                 match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    Some(value) => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::set_var(key, value)
+                        }
+                    }
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    None => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::remove_var(key)
+                        }
+                    }
                 }
             }
         }

--- a/crates/router/src/services/worker_process.rs
+++ b/crates/router/src/services/worker_process.rs
@@ -530,15 +530,15 @@ fn append_one_shot_worker_stderr_log(
     let Some(path) = worker_stderr_log_path(worker_id, service_name, env) else {
         return;
     };
-    if let Some(parent) = path.parent() {
-        if let Err(error) = std::fs::create_dir_all(parent) {
-            warn!(
-                path = %path.display(),
-                error = %error,
-                "failed to create one-shot worker stderr log directory"
-            );
-            return;
-        }
+    if let Some(parent) = path.parent()
+        && let Err(error) = std::fs::create_dir_all(parent)
+    {
+        warn!(
+            path = %path.display(),
+            error = %error,
+            "failed to create one-shot worker stderr log directory"
+        );
+        return;
     }
     match OpenOptions::new().create(true).append(true).open(&path) {
         Ok(mut file) => {
@@ -705,14 +705,14 @@ fn configure_worker_stderr(
         command.stderr(Stdio::null());
         return;
     };
-    if let Some(parent) = path.parent() {
-        if let Err(error) = std::fs::create_dir_all(parent) {
-            warn!(
-                path = %path.display(),
-                error = %error,
-                "failed to create worker stderr log directory"
-            );
-        }
+    if let Some(parent) = path.parent()
+        && let Err(error) = std::fs::create_dir_all(parent)
+    {
+        warn!(
+            path = %path.display(),
+            error = %error,
+            "failed to create worker stderr log directory"
+        );
     }
     match OpenOptions::new().create(true).append(true).open(&path) {
         Ok(file) => {

--- a/crates/router/tests/business/registry_lifecycle_flow.rs
+++ b/crates/router/tests/business/registry_lifecycle_flow.rs
@@ -524,7 +524,14 @@ impl ProjectEnv {
         std::fs::create_dir_all(temp.path().join("personas").join("src"))?;
         std::fs::create_dir_all(temp.path().join("commands"))?;
         let previous_project_root = std::env::var_os("TURA_PROJECT_ROOT");
-        std::env::set_var("TURA_PROJECT_ROOT", temp.path());
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", temp.path())
+        };
         Ok(Self {
             temp,
             previous_project_root,
@@ -539,8 +546,26 @@ impl ProjectEnv {
 impl Drop for ProjectEnv {
     fn drop(&mut self) {
         match self.previous_project_root.take() {
-            Some(value) => std::env::set_var("TURA_PROJECT_ROOT", value),
-            None => std::env::remove_var("TURA_PROJECT_ROOT"),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("TURA_PROJECT_ROOT", value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var("TURA_PROJECT_ROOT")
+                }
+            }
         }
     }
 }

--- a/crates/router/tests/os_testing/worker_lifecycle_flow.rs
+++ b/crates/router/tests/os_testing/worker_lifecycle_flow.rs
@@ -657,9 +657,30 @@ async fn router_worker_business_flow_startup_cleanup_kills_orphan_runtime_proces
     let previous_home = std::env::var_os("TURA_HOME");
     let previous_session_root = std::env::var_os("SESSION_LOG_DB_ROOT");
     let previous_tura_root = std::env::var_os("TURA_DB_ROOT");
-    std::env::set_var("TURA_HOME", &home);
-    std::env::remove_var("SESSION_LOG_DB_ROOT");
-    std::env::remove_var("TURA_DB_ROOT");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_HOME", &home)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("SESSION_LOG_DB_ROOT")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_DB_ROOT")
+    };
 
     let mut child = ChildCleanup::new(
         Command::new(python_executable()?)
@@ -849,8 +870,22 @@ fn process_alive(pid: u32) -> bool {
 
 fn restore_env(key: &str, previous: Option<std::ffi::OsString>) {
     if let Some(value) = previous {
-        std::env::set_var(key, value);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(key, value)
+        };
     } else {
-        std::env::remove_var(key);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(key)
+        };
     }
 }

--- a/crates/runtime/src/bin/mock_router_for_test.rs
+++ b/crates/runtime/src/bin/mock_router_for_test.rs
@@ -73,54 +73,54 @@ fn main() {
         .unwrap_or(0);
 
     let mut child_summary: Option<String> = None;
-    if depth < target_depth {
-        if let Ok(self_bin) = std::env::current_exe() {
-            let child_req = json!({
-                "session_id": format!("{session_id}-child"),
-                "agent": format!("{agent}.child"),
-                "prompt": "recursive-child",
-                "parent_session_id": session_id,
-                "depth": depth + 1,
-            });
-            let body = serde_json::to_string(&child_req).unwrap_or_default();
-            let mut child = match Command::new(&self_bin)
-                .arg("run-agent")
-                .env_remove("MOCK_RECURSE_TO_DEPTH")
-                .env(
-                    "MOCK_AGENT_SUMMARY",
-                    format!("{agent}.child@depth{}", depth + 1),
-                )
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null())
-                .spawn()
-            {
-                Ok(c) => c,
-                Err(error) => {
-                    emit_error(&format!("recursive spawn failed: {error}"));
-                    return;
-                }
-            };
-            if let Some(mut stdin) = child.stdin.take() {
-                let _ = stdin.write_all(body.as_bytes());
+    if depth < target_depth
+        && let Ok(self_bin) = std::env::current_exe()
+    {
+        let child_req = json!({
+            "session_id": format!("{session_id}-child"),
+            "agent": format!("{agent}.child"),
+            "prompt": "recursive-child",
+            "parent_session_id": session_id,
+            "depth": depth + 1,
+        });
+        let body = serde_json::to_string(&child_req).unwrap_or_default();
+        let mut child = match Command::new(&self_bin)
+            .arg("run-agent")
+            .env_remove("MOCK_RECURSE_TO_DEPTH")
+            .env(
+                "MOCK_AGENT_SUMMARY",
+                format!("{agent}.child@depth{}", depth + 1),
+            )
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(error) => {
+                emit_error(&format!("recursive spawn failed: {error}"));
+                return;
             }
-            let out = match child.wait_with_output() {
-                Ok(o) => o,
-                Err(error) => {
-                    emit_error(&format!("recursive wait failed: {error}"));
-                    return;
-                }
-            };
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            if let Ok(v) = serde_json::from_str::<Value>(stdout.trim()) {
-                let s = v
-                    .get("result")
-                    .and_then(|r| r.get("summary"))
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string();
-                child_summary = Some(s);
+        };
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(body.as_bytes());
+        }
+        let out = match child.wait_with_output() {
+            Ok(o) => o,
+            Err(error) => {
+                emit_error(&format!("recursive wait failed: {error}"));
+                return;
             }
+        };
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        if let Ok(v) = serde_json::from_str::<Value>(stdout.trim()) {
+            let s = v
+                .get("result")
+                .and_then(|r| r.get("summary"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            child_summary = Some(s);
         }
     }
 

--- a/crates/runtime/src/bin/tura_runtime.rs
+++ b/crates/runtime/src/bin/tura_runtime.rs
@@ -8,7 +8,21 @@
 
 fn main() -> std::io::Result<()> {
     tura_path::process_hardening::harden_current_process("runtime_worker");
-    std::env::set_var("TURA_ROLE", "runtime_worker");
-    std::env::set_var("TURA_RUNTIME_WORKER", "1");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_ROLE", "runtime_worker")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_RUNTIME_WORKER", "1")
+    };
     runtime::worker::run()
 }

--- a/crates/runtime/src/checkpoint/session_snapshot.rs
+++ b/crates/runtime/src/checkpoint/session_snapshot.rs
@@ -476,10 +476,8 @@ fn conversation_message_record(
         "tool": null,
         "state": null,
     });
-    if !has_metadata {
-        if let Some(part_object) = part.as_object_mut() {
-            part_object.remove("metadata");
-        }
+    if !has_metadata && let Some(part_object) = part.as_object_mut() {
+        part_object.remove("metadata");
     }
 
     Some(serde_json::json!({

--- a/crates/runtime/src/context/build.rs
+++ b/crates/runtime/src/context/build.rs
@@ -54,15 +54,15 @@ pub fn build_context(input: ContextInput<'_>) -> Result<ContextOutput, String> {
     };
 
     if messages.is_empty() {
-        if let Some(reasoning) = &input.runtime.reasoning {
-            if !reasoning.is_empty() {
-                context_state.reasoning_history.push(reasoning.clone());
-                messages.push(serde_json::json!({
-                    "role": "system",
-                    "type": "reasoning",
-                    "content": reasoning,
-                }));
-            }
+        if let Some(reasoning) = &input.runtime.reasoning
+            && !reasoning.is_empty()
+        {
+            context_state.reasoning_history.push(reasoning.clone());
+            messages.push(serde_json::json!({
+                "role": "system",
+                "type": "reasoning",
+                "content": reasoning,
+            }));
         }
 
         if !input.runtime.text.is_empty() {
@@ -71,10 +71,10 @@ pub fn build_context(input: ContextInput<'_>) -> Result<ContextOutput, String> {
                 "content": input.runtime.text,
             }));
         }
-    } else if let Some(reasoning) = &input.runtime.reasoning {
-        if !reasoning.is_empty() {
-            context_state.reasoning_history.push(reasoning.clone());
-        }
+    } else if let Some(reasoning) = &input.runtime.reasoning
+        && !reasoning.is_empty()
+    {
+        context_state.reasoning_history.push(reasoning.clone());
     }
 
     for tool_call in &input.runtime.tool_call {
@@ -86,10 +86,10 @@ pub fn build_context(input: ContextInput<'_>) -> Result<ContextOutput, String> {
         }));
     }
 
-    if input.session.use_last_tool_call_response {
-        if let Some(last_tool_call_response) = last_tool_call_response_from_session(input.session) {
-            context_state.last_tool_call_response = Some(last_tool_call_response);
-        }
+    if input.session.use_last_tool_call_response
+        && let Some(last_tool_call_response) = last_tool_call_response_from_session(input.session)
+    {
+        context_state.last_tool_call_response = Some(last_tool_call_response);
     }
 
     for msg in &input.additional_messages {
@@ -441,33 +441,32 @@ fn immutable_context_messages_from_log_entry(value: serde_json::Value) -> Vec<se
     let Some(obj) = value.as_object() else {
         return Vec::new();
     };
-    if let Some(role) = obj.get("role").and_then(|role| role.as_str()) {
-        if role == USER_AGENT_CONTEXT_ROLE
+    if let Some(role) = obj.get("role").and_then(|role| role.as_str())
+        && (role == USER_AGENT_CONTEXT_ROLE
             || role == "user"
             || role == "system"
             || role == "developer"
-            || role == "assistant"
-        {
-            let content = obj.get("content");
-            let provider_role = if role == USER_AGENT_CONTEXT_ROLE {
-                if content.is_some_and(is_developer_context_injection) {
-                    "developer"
-                } else {
-                    "user"
-                }
+            || role == "assistant")
+    {
+        let content = obj.get("content");
+        let provider_role = if role == USER_AGENT_CONTEXT_ROLE {
+            if content.is_some_and(is_developer_context_injection) {
+                "developer"
             } else {
-                role
-            };
-            return obj
-                .get("content")
-                .map(|content| {
-                    vec![serde_json::json!({
-                    "role": provider_role,
-                    "content": content,
-                    })]
-                })
-                .unwrap_or_default();
-        }
+                "user"
+            }
+        } else {
+            role
+        };
+        return obj
+            .get("content")
+            .map(|content| {
+                vec![serde_json::json!({
+                "role": provider_role,
+                "content": content,
+                })]
+            })
+            .unwrap_or_default();
     }
 
     if obj.get("type").and_then(|kind| kind.as_str()) != Some("tool_result") {
@@ -477,16 +476,14 @@ fn immutable_context_messages_from_log_entry(value: serde_json::Value) -> Vec<se
     if let Some(messages) = obj
         .get("context_messages")
         .and_then(|messages| messages.as_array())
+        && (value.get("tool_name").and_then(|name| name.as_str()) != Some("command_run")
+            || command_run_cached_context_messages_are_valid(messages))
     {
-        if value.get("tool_name").and_then(|name| name.as_str()) != Some("command_run")
-            || command_run_cached_context_messages_are_valid(messages)
-        {
-            return messages
-                .iter()
-                .cloned()
-                .map(strip_context_reporting_fields)
-                .collect();
-        }
+        return messages
+            .iter()
+            .cloned()
+            .map(strip_context_reporting_fields)
+            .collect();
     }
 
     immutable_tool_result_context_messages(&value)
@@ -886,7 +883,11 @@ mod tests {
             .find("Goal-mode last user command from session state")
             .expect("goal heading");
         assert!(
-            old_user < summary && summary < user && user < agent && agent < agent_handoff && agent_handoff < goal,
+            old_user < summary
+                && summary < user
+                && user < agent
+                && agent < agent_handoff
+                && agent_handoff < goal,
             "compact rebuild must order previous compact summaries, user/agent history, agent handoff, then goal: {joined}"
         );
     }

--- a/crates/runtime/src/context/media.rs
+++ b/crates/runtime/src/context/media.rs
@@ -110,14 +110,13 @@ fn command_run_media_image_urls(value: &serde_json::Value) -> Vec<String> {
 fn collect_command_run_media_image_urls(value: &serde_json::Value, urls: &mut Vec<String>) {
     match value {
         serde_json::Value::Object(object) => {
-            if object.get("type").and_then(serde_json::Value::as_str) == Some("image_url") {
-                if let Some(url) = object
+            if object.get("type").and_then(serde_json::Value::as_str) == Some("image_url")
+                && let Some(url) = object
                     .get("image_url")
                     .and_then(|image_url| image_url.get("url"))
                     .and_then(serde_json::Value::as_str)
-                {
-                    urls.push(url.to_string());
-                }
+            {
+                urls.push(url.to_string());
             }
             for child in object.values() {
                 collect_command_run_media_image_urls(child, urls);
@@ -149,28 +148,27 @@ fn collect_command_run_media_input_files(
 ) {
     match value {
         serde_json::Value::Object(object) => {
-            if object.get("type").and_then(serde_json::Value::as_str) == Some("file") {
-                if let Some(data) = object
+            if object.get("type").and_then(serde_json::Value::as_str) == Some("file")
+                && let Some(data) = object
                     .get("data_base64")
                     .and_then(serde_json::Value::as_str)
-                {
-                    let file_name = object
-                        .get("file_name")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or("attachment");
-                    let mime_type = object
-                        .get("mime_type")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or("application/octet-stream");
-                    if mime_type == "application/octet-stream" {
-                        return;
-                    }
-                    inputs.push(serde_json::json!({
-                        "type": "input_file",
-                        "filename": file_name,
-                        "file_data": format!("data:{mime_type};base64,{data}"),
-                    }));
+            {
+                let file_name = object
+                    .get("file_name")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("attachment");
+                let mime_type = object
+                    .get("mime_type")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("application/octet-stream");
+                if mime_type == "application/octet-stream" {
+                    return;
                 }
+                inputs.push(serde_json::json!({
+                    "type": "input_file",
+                    "filename": file_name,
+                    "file_data": format!("data:{mime_type};base64,{data}"),
+                }));
             }
             for child in object.values() {
                 collect_command_run_media_input_files(child, inputs);

--- a/crates/runtime/src/context/text_truncate.rs
+++ b/crates/runtime/src/context/text_truncate.rs
@@ -236,10 +236,10 @@ fn extract_read_targets(command_line: &str) -> Vec<String> {
                     next += 1;
                     continue;
                 }
-                if let Some(path) = normalize_read_target(&tokens[next]) {
-                    if !targets.iter().any(|existing| existing == &path) {
-                        targets.push(path);
-                    }
+                if let Some(path) = normalize_read_target(&tokens[next])
+                    && !targets.iter().any(|existing| existing == &path)
+                {
+                    targets.push(path);
                 }
                 next += 1;
             }

--- a/crates/runtime/src/context/tool_results.rs
+++ b/crates/runtime/src/context/tool_results.rs
@@ -468,13 +468,12 @@ pub(super) fn flattened_command_run_results(output: &serde_json::Value) -> Vec<&
     };
     let mut flattened = Vec::new();
     for result in results {
-        if result.get("mode").and_then(|mode| mode.as_str()) == Some("batch") {
-            if let Some(batch_results) =
+        if result.get("mode").and_then(|mode| mode.as_str()) == Some("batch")
+            && let Some(batch_results) =
                 result.get("results").and_then(|results| results.as_array())
-            {
-                flattened.extend(batch_results);
-                continue;
-            }
+        {
+            flattened.extend(batch_results);
+            continue;
         }
         flattened.push(result);
     }

--- a/crates/runtime/src/context/workspace.rs
+++ b/crates/runtime/src/context/workspace.rs
@@ -291,11 +291,9 @@ fn recent_file_lines(
     recent_files: &[WorkspaceSnapshotEntry],
     omitted_recent_files: usize,
 ) -> Vec<String> {
-    let mut lines = vec![
-        format!(
-            "recent_files: relative paths modified in the last {RECENT_FILE_DAYS} days, newest first, max {MAX_RECENT_FILES}"
-        ),
-    ];
+    let mut lines = vec![format!(
+        "recent_files: relative paths modified in the last {RECENT_FILE_DAYS} days, newest first, max {MAX_RECENT_FILES}"
+    )];
     lines.extend(recent_files.iter().map(format_entry_line));
     if omitted_recent_files > 0 {
         lines.push(format!(

--- a/crates/runtime/src/gateway_events/agent_message.rs
+++ b/crates/runtime/src/gateway_events/agent_message.rs
@@ -179,12 +179,12 @@ pub(crate) fn publish_feed_event(
 }
 
 pub(crate) fn frontend_session_id(session_id: &str) -> String {
-    if planning_child_depth_from_env() > 0 {
-        if let Ok(parent_session_id) = std::env::var("TURA_PARENT_SESSION_ID") {
-            let parent_session_id = parent_session_id.trim();
-            if !parent_session_id.is_empty() {
-                return parent_session_id.to_string();
-            }
+    if planning_child_depth_from_env() > 0
+        && let Ok(parent_session_id) = std::env::var("TURA_PARENT_SESSION_ID")
+    {
+        let parent_session_id = parent_session_id.trim();
+        if !parent_session_id.is_empty() {
+            return parent_session_id.to_string();
         }
     }
 
@@ -220,20 +220,62 @@ mod tests {
         let _guard = ENV_LOCK.lock().expect("env lock");
         clear_gateway_env();
 
-        std::env::set_var("TURA_PARENT_SESSION_ID", " parent-session ");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PARENT_SESSION_ID", " parent-session ")
+        };
         assert_eq!(frontend_session_id("child-session"), "child-session");
 
-        std::env::set_var("TURA_PLANNING_DEPTH", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PLANNING_DEPTH", "1")
+        };
         assert_eq!(frontend_session_id("child-session"), "parent-session");
 
-        std::env::set_var("TURA_PARENT_SESSION_ID", "   ");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PARENT_SESSION_ID", "   ")
+        };
         assert_eq!(frontend_session_id("child-session"), "child-session");
 
-        std::env::set_var("TURA_PLANNING_DEPTH", "2");
-        std::env::set_var("TURA_PARENT_SESSION_ID", "execute-parent");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PLANNING_DEPTH", "2")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PARENT_SESSION_ID", "execute-parent")
+        };
         assert_eq!(frontend_session_id("child-session"), "execute-parent");
 
-        std::env::set_var("TURA_PLANNING_DEPTH", "not-a-number");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PLANNING_DEPTH", "not-a-number")
+        };
         assert_eq!(frontend_session_id("child-session"), "child-session");
     }
 
@@ -274,7 +316,14 @@ mod tests {
             "TURA_PLANNING_DEPTH",
             "TURA_CLI_LIVE_JSONL",
         ] {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 }

--- a/crates/runtime/src/gateway_events/cli_live.rs
+++ b/crates/runtime/src/gateway_events/cli_live.rs
@@ -203,15 +203,15 @@ fn redact_media_payload_data(value: &mut serde_json::Value) {
                     }),
                 );
             }
-            if let Some(serde_json::Value::String(url)) = object.get_mut("url") {
-                if is_base64_data_url(url) {
-                    *url = "[redacted media data URL]".to_string();
-                }
+            if let Some(serde_json::Value::String(url)) = object.get_mut("url")
+                && is_base64_data_url(url)
+            {
+                *url = "[redacted media data URL]".to_string();
             }
-            if let Some(serde_json::Value::String(data)) = object.get_mut("data_base64") {
-                if !data.is_empty() {
-                    *data = "[redacted base64 file payload]".to_string();
-                }
+            if let Some(serde_json::Value::String(data)) = object.get_mut("data_base64")
+                && !data.is_empty()
+            {
+                *data = "[redacted base64 file payload]".to_string();
             }
             for child in object.values_mut() {
                 redact_media_payload_data(child);

--- a/crates/runtime/src/gateway_events/tool_message.rs
+++ b/crates/runtime/src/gateway_events/tool_message.rs
@@ -20,10 +20,10 @@ pub(crate) fn summarize_single_tool_output(tool_name: &str, output: &serde_json:
     if let Some(markdown) = first_summary_markdown(output) {
         return markdown.lines().take(10).collect::<Vec<_>>().join("\n");
     }
-    if tool_name == "command_run" {
-        if let Some(summary) = summarize_command_run_output(output) {
-            return summary;
-        }
+    if tool_name == "command_run"
+        && let Some(summary) = summarize_command_run_output(output)
+    {
+        return summary;
     }
 
     if matches!(tool_name, "find" | "glob") {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::unwrap_used)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![allow(ambiguous_glob_reexports)]
 
 pub mod agent_router;

--- a/crates/runtime/src/manas/agent_prompts.rs
+++ b/crates/runtime/src/manas/agent_prompts.rs
@@ -220,9 +220,30 @@ mod tests {
         )
         .expect("persona config should be written");
 
-        std::env::set_var("TURA_SESSION_PERSONA", "guide");
-        std::env::set_var("TURA_PROJECT_ROOT", &root);
-        std::env::remove_var("TURA_FRONTEND_SOURCE");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_PERSONA", "guide")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", &root)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_FRONTEND_SOURCE")
+        };
 
         let mut agent = test_agent(&agent_dir, "coding_agent");
         agent.add_prompt(AgentPromptItem {
@@ -292,9 +313,30 @@ mod tests {
         )
         .expect("cli communication style should be written");
 
-        std::env::remove_var("TURA_SESSION_PERSONA");
-        std::env::set_var("TURA_PROJECT_ROOT", &root);
-        std::env::set_var("TURA_FRONTEND_SOURCE", "cli");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_SESSION_PERSONA")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", &root)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_FRONTEND_SOURCE", "cli")
+        };
 
         let mut agent = test_agent(&agent_dir, "coding_agent");
         agent.add_prompt(AgentPromptItem {
@@ -381,10 +423,31 @@ mod tests {
             prompt_directory: agent_dir,
         });
 
-        std::env::set_var("TURA_PROJECT_ROOT", &root);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", &root)
+        };
 
-        std::env::remove_var("TURA_SESSION_PERSONA");
-        std::env::remove_var("TURA_FRONTEND_SOURCE");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_SESSION_PERSONA")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_FRONTEND_SOURCE")
+        };
         assert_eq!(
             message_contents(
                 &load_agent_system_prompt_messages(&agent).expect("gui without persona")
@@ -392,22 +455,64 @@ mod tests {
             vec!["agent prompt"]
         );
 
-        std::env::set_var("TURA_SESSION_PERSONA", "guide");
-        std::env::remove_var("TURA_FRONTEND_SOURCE");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_PERSONA", "guide")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_FRONTEND_SOURCE")
+        };
         assert_eq!(
             message_contents(&load_agent_system_prompt_messages(&agent).expect("gui persona")),
             vec!["persona prompt", "gui communication style", "agent prompt"]
         );
 
-        std::env::remove_var("TURA_SESSION_PERSONA");
-        std::env::set_var("TURA_FRONTEND_SOURCE", "cli");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_SESSION_PERSONA")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_FRONTEND_SOURCE", "cli")
+        };
         assert_eq!(
             message_contents(&load_agent_system_prompt_messages(&agent).expect("cli no persona")),
             vec!["cli communication style", "agent prompt"]
         );
 
-        std::env::set_var("TURA_SESSION_PERSONA", "guide");
-        std::env::set_var("TURA_FRONTEND_SOURCE", "cli");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_PERSONA", "guide")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_FRONTEND_SOURCE", "cli")
+        };
         assert_eq!(active_persona_display_name(&agent), None);
         assert_eq!(
             message_contents(&load_agent_system_prompt_messages(&agent).expect("cli persona")),
@@ -549,9 +654,23 @@ mod tests {
 
     fn restore_env(key: &str, value: Option<OsString>) {
         if let Some(value) = value {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         } else {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 }

--- a/crates/runtime/src/manas/child_dispatch.rs
+++ b/crates/runtime/src/manas/child_dispatch.rs
@@ -71,12 +71,12 @@ fn resolve_router_binary() -> Result<PathBuf, String> {
         }
     }
     // Sibling of the current exe (worker and router share the same target dir).
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            let candidate = dir.join(exe_name);
-            if candidate.exists() {
-                return Ok(candidate);
-            }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        let candidate = dir.join(exe_name);
+        if candidate.exists() {
+            return Ok(candidate);
         }
     }
 
@@ -185,10 +185,10 @@ pub fn dispatch_child_agents_concurrent(
 fn summarize_child_result(raw: &Value) -> String {
     let result = raw.get("result").unwrap_or(raw);
     for key in ["summary", "message", "output_text", "final_text", "text"] {
-        if let Some(text) = result.get(key).and_then(Value::as_str) {
-            if !text.trim().is_empty() {
-                return text.trim().to_string();
-            }
+        if let Some(text) = result.get(key).and_then(Value::as_str)
+            && !text.trim().is_empty()
+        {
+            return text.trim().to_string();
         }
     }
     if let Some(error) = raw.get("error").and_then(Value::as_str) {

--- a/crates/runtime/src/manas/final_response.rs
+++ b/crates/runtime/src/manas/final_response.rs
@@ -77,10 +77,10 @@ pub(crate) fn user_visible_runtime_output_text(output: &serde_json::Value) -> Op
         "content",
         "summary",
     ] {
-        if let Some(text) = output.get(key).and_then(serde_json::Value::as_str) {
-            if let Some(visible) = user_visible_runtime_text(text) {
-                return Some(visible);
-            }
+        if let Some(text) = output.get(key).and_then(serde_json::Value::as_str)
+            && let Some(visible) = user_visible_runtime_text(text)
+        {
+            return Some(visible);
         }
     }
     let content = tura_llm_rust::normalize_response_content(output);

--- a/crates/runtime/src/manas/process.rs
+++ b/crates/runtime/src/manas/process.rs
@@ -326,21 +326,21 @@ pub(crate) fn process_manas_internal(
             let visible_reply_before_tool = visible_runtime_reply(&runtime);
             let visible_reply_published_before_terminal_status =
                 visible_reply_before_tool.is_some();
-            if let Some(content) = visible_reply_before_tool.as_deref() {
-                if let Err(error) = publish_agent_message_from_runtime(
+            if let Some(content) = visible_reply_before_tool.as_deref()
+                && let Err(error) = publish_agent_message_from_runtime(
                     &session.session_id,
                     &runtime,
                     content.to_string(),
                     String::new(),
                     feed_publisher.as_ref(),
-                ) {
-                    warn!(
-                        session_id = %session.session_id,
-                        runtime_id = %runtime.runtime_id,
-                        error = %error,
-                        "failed to publish assistant text before tool execution"
-                    );
-                }
+                )
+            {
+                warn!(
+                    session_id = %session.session_id,
+                    runtime_id = %runtime.runtime_id,
+                    error = %error,
+                    "failed to publish assistant text before tool execution"
+                );
             }
             provider_timeout_retries = 0;
             no_tool_retries = 0;
@@ -549,21 +549,21 @@ pub(crate) fn process_manas_internal(
                 persist_session_checkpoint(&mut session_delta_writer, session, "task_focus")?;
             }
         } else {
-            if let Some(content) = visible_runtime_reply(&runtime) {
-                if let Err(error) = publish_agent_message_from_runtime(
+            if let Some(content) = visible_runtime_reply(&runtime)
+                && let Err(error) = publish_agent_message_from_runtime(
                     &session.session_id,
                     &runtime,
                     content,
                     String::new(),
                     feed_publisher.as_ref(),
-                ) {
-                    warn!(
-                        session_id = %session.session_id,
-                        runtime_id = %runtime.runtime_id,
-                        error = %error,
-                        "failed to publish final assistant message"
-                    );
-                }
+                )
+            {
+                warn!(
+                    session_id = %session.session_id,
+                    runtime_id = %runtime.runtime_id,
+                    error = %error,
+                    "failed to publish final assistant message"
+                );
             }
             seal_runtime_feed(&mut runtime_event_writer, &runtime.runtime_id)?;
             if let Some(summary) = auto_compact_summary_after_new_context(session, &runtime, &[]) {
@@ -964,21 +964,21 @@ fn run_terminal_final_response_turn(
     accumulate_session_from_runtime(session, &runtime, true)?;
     session.increment_turn(Utc::now());
     persist_session_checkpoint(session_delta_writer, session, "terminal_final_response")?;
-    if let Some(content) = visible_text {
-        if let Err(error) = publish_agent_message_from_runtime(
+    if let Some(content) = visible_text
+        && let Err(error) = publish_agent_message_from_runtime(
             &session.session_id,
             &runtime,
             content,
             String::new(),
             feed_publisher.as_ref(),
-        ) {
-            warn!(
-                session_id = %session.session_id,
-                runtime_id = %runtime.runtime_id,
-                error = %error,
-                "failed to publish terminal final response assistant message"
-            );
-        }
+        )
+    {
+        warn!(
+            session_id = %session.session_id,
+            runtime_id = %runtime.runtime_id,
+            error = %error,
+            "failed to publish terminal final response assistant message"
+        );
     }
     publish_runtime_usage_record(session, &runtime, feed_publisher.as_ref());
     if let Some(writer) = runtime_event_writer {
@@ -1130,19 +1130,54 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
         let previous = std::env::var_os("TURA_MANAS_MAX_TURNS");
 
-        std::env::set_var("TURA_MANAS_MAX_TURNS", "3");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_MANAS_MAX_TURNS", "3")
+        };
         assert_eq!(manas_max_turns(), 3);
 
-        std::env::set_var("TURA_MANAS_MAX_TURNS", "0");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_MANAS_MAX_TURNS", "0")
+        };
         assert_eq!(manas_max_turns(), DEFAULT_MANAS_MAX_TURNS);
 
-        std::env::set_var("TURA_MANAS_MAX_TURNS", "not-a-number");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_MANAS_MAX_TURNS", "not-a-number")
+        };
         assert_eq!(manas_max_turns(), DEFAULT_MANAS_MAX_TURNS);
 
         if let Some(previous) = previous {
-            std::env::set_var("TURA_MANAS_MAX_TURNS", previous);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_MANAS_MAX_TURNS", previous)
+            };
         } else {
-            std::env::remove_var("TURA_MANAS_MAX_TURNS");
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("TURA_MANAS_MAX_TURNS")
+            };
         }
     }
 
@@ -1594,7 +1629,14 @@ mod tests {
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
             Self { key, previous }
         }
     }
@@ -1602,9 +1644,23 @@ mod tests {
     impl Drop for EnvGuard {
         fn drop(&mut self) {
             if let Some(previous) = self.previous.take() {
-                std::env::set_var(self.key, previous);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(self.key, previous)
+                };
             } else {
-                std::env::remove_var(self.key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(self.key)
+                };
             }
         }
     }

--- a/crates/runtime/src/manas/runtime_turn.rs
+++ b/crates/runtime/src/manas/runtime_turn.rs
@@ -473,9 +473,30 @@ mod tests {
         )
         .expect("persona config should be written");
 
-        std::env::set_var("TURA_SESSION_PERSONA", "guide");
-        std::env::set_var("TURA_PROJECT_ROOT", &root);
-        std::env::remove_var("TURA_FRONTEND_SOURCE");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_PERSONA", "guide")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROJECT_ROOT", &root)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_FRONTEND_SOURCE")
+        };
 
         let agent = AgentManagement::new(
             "agent-id".to_string(),
@@ -609,7 +630,14 @@ mod tests {
             .lock()
             .unwrap_or_else(|err| err.into_inner());
         let _env = clean_context_limit_env();
-        std::env::set_var("COMMAND_RUN_AGENT_FIXED_CONTEXT_TOKENS", "4096");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("COMMAND_RUN_AGENT_FIXED_CONTEXT_TOKENS", "4096")
+        };
         let settings = settings_with_model_context("openai", "gpt-large", 1_000_000);
         let provider = runtime_provider("openai", "gpt-large");
 
@@ -748,9 +776,23 @@ mod tests {
 
     fn restore_env(key: &str, value: Option<OsString>) {
         if let Some(value) = value {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         } else {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 
@@ -771,8 +813,22 @@ mod tests {
             fixed: std::env::var_os("COMMAND_RUN_AGENT_FIXED_CONTEXT_TOKENS"),
             tura: std::env::var_os("TURA_CONTEXT_LIMIT_TOKENS"),
         };
-        std::env::remove_var("COMMAND_RUN_AGENT_FIXED_CONTEXT_TOKENS");
-        std::env::remove_var("TURA_CONTEXT_LIMIT_TOKENS");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("COMMAND_RUN_AGENT_FIXED_CONTEXT_TOKENS")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_CONTEXT_LIMIT_TOKENS")
+        };
         guard
     }
 

--- a/crates/runtime/src/manas/tool_arguments.rs
+++ b/crates/runtime/src/manas/tool_arguments.rs
@@ -33,14 +33,13 @@ fn normalize_command_run_arguments(
     mut arguments: serde_json::Value,
     session_directory: &Path,
 ) -> serde_json::Value {
-    if let Some(object) = arguments.as_object_mut() {
-        if let Some(commands) = object
+    if let Some(object) = arguments.as_object_mut()
+        && let Some(commands) = object
             .get_mut("commands")
             .and_then(|value| value.as_array_mut())
-        {
-            for command in commands {
-                normalize_command_run_command(command, session_directory);
-            }
+    {
+        for command in commands {
+            normalize_command_run_command(command, session_directory);
         }
     }
     arguments
@@ -133,10 +132,10 @@ pub(super) fn normalize_workspace_path_fields(
     session_directory: &Path,
 ) {
     for field in ["path", "directory"] {
-        if let Some(value) = object.get_mut(field) {
-            if let Some(path) = value.as_str() {
-                *value = serde_json::Value::String(resolve_workspace_path(session_directory, path));
-            }
+        if let Some(value) = object.get_mut(field)
+            && let Some(path) = value.as_str()
+        {
+            *value = serde_json::Value::String(resolve_workspace_path(session_directory, path));
         }
     }
 }

--- a/crates/runtime/src/manas/tool_catalog.rs
+++ b/crates/runtime/src/manas/tool_catalog.rs
@@ -217,10 +217,10 @@ fn tool_interface_to_provider_schema_with_commands(
             .cloned()
             .unwrap_or_else(|| serde_json::json!({ "type": "object" })),
     );
-    if name == COMMAND_RUN_TOOL {
-        if let Some(commands) = allowed_commands {
-            input_schema = restrict_command_run_schema(input_schema, commands);
-        }
+    if name == COMMAND_RUN_TOOL
+        && let Some(commands) = allowed_commands
+    {
+        input_schema = restrict_command_run_schema(input_schema, commands);
     }
     let mut parameters =
         if input_schema.get("type").and_then(|value| value.as_str()) == Some("array") {
@@ -881,7 +881,14 @@ mod tests {
     #[test]
     fn empty_agent_capabilities_do_not_enable_default_command_run_commands() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+        };
         let agent = command_run_agent_with_capabilities(&[]);
 
         let commands = command_run_commands_for_agent(&agent);
@@ -890,13 +897,27 @@ mod tests {
             commands.is_empty(),
             "an agent with no capabilities must not receive default command_run commands"
         );
-        std::env::remove_var("TURA_COMMAND_RUN_SHELL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_SHELL")
+        };
     }
 
     #[test]
     fn empty_agent_capabilities_do_not_load_command_run_provider_tool() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+        };
         let agent = command_run_agent_with_capabilities(&[]);
         let session = session_with_task_type(vec!["debug".to_string()]);
         let commands = command_run_commands_for_agent(&agent);
@@ -908,13 +929,27 @@ mod tests {
             tools.is_empty(),
             "an agent with no capabilities must not receive the command_run provider tool"
         );
-        std::env::remove_var("TURA_COMMAND_RUN_SHELL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_SHELL")
+        };
     }
 
     #[test]
     fn runtime_prompt_capabilities_extend_command_run_schema() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+        };
         let mut commands = command_run_commands_for_agent(&command_run_agent_with_capabilities(&[
             "command_run",
             "apply_patch",
@@ -944,13 +979,27 @@ mod tests {
                 "task_status",
             ],
         );
-        std::env::remove_var("TURA_COMMAND_RUN_SHELL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_SHELL")
+        };
     }
 
     #[test]
     fn provider_schema_preserves_additional_properties_recursively() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        std::env::set_var("TURA_COMMAND_RUN_DISABLE_STRICT_JSON", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_DISABLE_STRICT_JSON", "1")
+        };
 
         let schema = tool_interface_to_provider_schema(serde_json::json!({
             "name": "example",
@@ -976,13 +1025,27 @@ mod tests {
         assert!(schema.to_string().contains("additionalProperties"));
         assert_eq!(schema["function"]["strict"], false);
 
-        std::env::remove_var("TURA_COMMAND_RUN_DISABLE_STRICT_JSON");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_DISABLE_STRICT_JSON")
+        };
     }
 
     #[test]
     fn strict_json_env_requires_all_provider_object_fields() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        std::env::set_var("TURA_COMMAND_RUN_STRICT_JSON", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_STRICT_JSON", "1")
+        };
 
         let schema = tool_interface_to_provider_schema(command_run_interface());
         let parameters = &schema["function"]["parameters"];
@@ -994,13 +1057,27 @@ mod tests {
             serde_json::json!(["command_type", "command_line", "step"])
         );
 
-        std::env::remove_var("TURA_COMMAND_RUN_STRICT_JSON");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_STRICT_JSON")
+        };
     }
 
     #[test]
     fn real_command_run_provider_schema_is_openai_strict_compatible() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        std::env::set_var("TURA_COMMAND_RUN_STRICT_JSON", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_STRICT_JSON", "1")
+        };
 
         let interface = serde_json::from_str::<serde_json::Value>(include_str!(
             "../../../tools/src/command_run/schema.json"
@@ -1022,13 +1099,27 @@ mod tests {
         assert!(parameters["properties"].get("task_status").is_none());
         assert!(command_required.contains(&serde_json::json!("command_type")));
         assert!(command_required.contains(&serde_json::json!("step")));
-        std::env::remove_var("TURA_COMMAND_RUN_STRICT_JSON");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_STRICT_JSON")
+        };
     }
 
     #[test]
     fn command_run_provider_schema_exposes_only_shell_command_surface() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+        };
 
         let commands = default_command_run_commands();
         let schema = tool_interface_to_provider_schema_with_commands(
@@ -1056,13 +1147,27 @@ mod tests {
             "integer"
         );
 
-        std::env::remove_var("TURA_COMMAND_RUN_SHELL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_SHELL")
+        };
     }
 
     #[test]
     fn command_run_provider_schema_exposes_only_bash_surface() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash")
+        };
 
         let commands = default_command_run_commands();
         let schema = tool_interface_to_provider_schema_with_commands(
@@ -1075,13 +1180,27 @@ mod tests {
             &["apply_patch", "bash", "web_discover", "task_status"],
         );
 
-        std::env::remove_var("TURA_COMMAND_RUN_SHELL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_SHELL")
+        };
     }
 
     #[test]
     fn command_run_provider_schema_exposes_only_zsh_surface() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        std::env::set_var("TURA_COMMAND_RUN_SHELL", "zsh");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_SHELL", "zsh")
+        };
 
         let commands = default_command_run_commands();
         let schema = tool_interface_to_provider_schema_with_commands(
@@ -1094,13 +1213,27 @@ mod tests {
             &["apply_patch", "zsh", "web_discover", "task_status"],
         );
 
-        std::env::remove_var("TURA_COMMAND_RUN_SHELL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_SHELL")
+        };
     }
 
     #[test]
     fn command_run_provider_schema_injects_planning_only_when_enabled() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+        };
         let mut commands = default_command_run_commands();
         commands.insert("planning".to_string());
 
@@ -1121,7 +1254,14 @@ mod tests {
             ],
         );
 
-        std::env::remove_var("TURA_COMMAND_RUN_SHELL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_SHELL")
+        };
     }
 
     #[test]
@@ -1175,7 +1315,14 @@ mod tests {
             });
         }
 
-        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+        };
         let session = session_with_task_type(vec!["debug".to_string()]);
         let allowed_commands = command_run_commands_for_agent(&agent);
         let tools = load_agent_capabilities_with_commands(&agent, &session, &allowed_commands)
@@ -1186,7 +1333,14 @@ mod tests {
             &["apply_patch", "shell_command", "task_status", "planning"],
         );
 
-        std::env::remove_var("TURA_COMMAND_RUN_SHELL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_COMMAND_RUN_SHELL")
+        };
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/runtime/src/prompt_style/task_status.rs
+++ b/crates/runtime/src/prompt_style/task_status.rs
@@ -26,11 +26,11 @@ pub fn task_status_schema(require_startup_task_state: bool) -> String {
         return code_tools::commands::task_status::SCHEMA.to_string();
     };
     let ids = super::runtime_prompt_manual::valid_task_type_ids();
-    if !ids.is_empty() {
-        if let Some(items) = schema.pointer_mut("/properties/task_type/items") {
-            items["enum"] =
-                serde_json::Value::Array(ids.into_iter().map(serde_json::Value::String).collect());
-        }
+    if !ids.is_empty()
+        && let Some(items) = schema.pointer_mut("/properties/task_type/items")
+    {
+        items["enum"] =
+            serde_json::Value::Array(ids.into_iter().map(serde_json::Value::String).collect());
     }
     let catalog = super::runtime_prompt_manual::task_type_catalog_for_schema_description();
     if let Some(task_type) = schema.pointer_mut("/properties/task_type") {

--- a/crates/runtime/src/provider_flow/call.rs
+++ b/crates/runtime/src/provider_flow/call.rs
@@ -421,7 +421,14 @@ mod tests {
 
     #[tokio::test]
     async fn call_runtime_provider_config_failure_finishes_failed_without_network() {
-        std::env::remove_var("DEFINITELY_MISSING_PROVIDER_FOR_CALL_RUNTIME_TEST_API_KEY");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("DEFINITELY_MISSING_PROVIDER_FOR_CALL_RUNTIME_TEST_API_KEY")
+        };
         let settings = missing_key_settings();
         let config = Arc::new(TuraConfig::new(".env.missing-for-call-runtime-test"));
 

--- a/crates/runtime/src/provider_flow/command_run_streaming.rs
+++ b/crates/runtime/src/provider_flow/command_run_streaming.rs
@@ -768,10 +768,10 @@ fn attach_result_identity(result: &mut Value, command: &Value) {
         "provider_tool_call_id",
         "command_index",
     ] {
-        if !result_object.contains_key(key) {
-            if let Some(value) = command.get(key).cloned() {
-                result_object.insert(key.to_string(), value);
-            }
+        if !result_object.contains_key(key)
+            && let Some(value) = command.get(key).cloned()
+        {
+            result_object.insert(key.to_string(), value);
         }
     }
     if !result_object.contains_key("command") {
@@ -1600,7 +1600,14 @@ mod tests {
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
             Self { key, previous }
         }
     }
@@ -1608,9 +1615,23 @@ mod tests {
     impl Drop for EnvGuard {
         fn drop(&mut self) {
             if let Some(previous) = self.previous.take() {
-                std::env::set_var(self.key, previous);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(self.key, previous)
+                };
             } else {
-                std::env::remove_var(self.key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(self.key)
+                };
             }
         }
     }

--- a/crates/runtime/src/provider_flow/errors.rs
+++ b/crates/runtime/src/provider_flow/errors.rs
@@ -161,7 +161,14 @@ mod tests {
     fn provider_timeout_retry_waits_use_three_step_backoff() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
         let previous = std::env::var_os("TURA_PROVIDER_RETRY_BACKOFF_MS");
-        std::env::remove_var("TURA_PROVIDER_RETRY_BACKOFF_MS");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_PROVIDER_RETRY_BACKOFF_MS")
+        };
         assert_eq!(
             super::provider_timeout_retry_wait(0),
             Some(std::time::Duration::from_secs(5))
@@ -182,7 +189,14 @@ mod tests {
     fn provider_timeout_retry_wait_allows_fast_business_test_override() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
         let previous = std::env::var_os("TURA_PROVIDER_RETRY_BACKOFF_MS");
-        std::env::set_var("TURA_PROVIDER_RETRY_BACKOFF_MS", "0,1,2");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_PROVIDER_RETRY_BACKOFF_MS", "0,1,2")
+        };
 
         assert_eq!(
             super::provider_timeout_retry_wait(0),
@@ -255,7 +269,9 @@ mod tests {
         assert!(super::runtime_failure_allows_retry(&runtime));
         assert_eq!(
             super::runtime_failure_text(&runtime).as_deref(),
-            Some("all providers failed: openai:gpt-5.1 => network error: error decoding response body")
+            Some(
+                "all providers failed: openai:gpt-5.1 => network error: error decoding response body"
+            )
         );
     }
 
@@ -314,9 +330,23 @@ mod tests {
 
     fn restore_env(key: &str, previous: Option<std::ffi::OsString>) {
         if let Some(previous) = previous {
-            std::env::set_var(key, previous);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, previous)
+            };
         } else {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 }

--- a/crates/runtime/src/provider_flow/provider_streaming.rs
+++ b/crates/runtime/src/provider_flow/provider_streaming.rs
@@ -79,12 +79,11 @@ pub(crate) async fn call_runtime_streaming(
         ) {
             command_state_for_sink.mark_seen();
         }
-        if let tura_llm_rust::ProviderStreamEvent::TextDelta { text } = &event {
-            if let Err(error) =
+        if let tura_llm_rust::ProviderStreamEvent::TextDelta { text } = &event
+            && let Err(error) =
                 publish_streamed_agent_text(&text_delta_runtime, text, text_feed_publisher.as_ref())
-            {
-                tracing::warn!(error = %error, "failed to queue assistant text feed event");
-            }
+        {
+            tracing::warn!(error = %error, "failed to queue assistant text feed event");
         }
         let _ = stream_tx.send(event);
     });

--- a/crates/runtime/src/provider_flow/request_options.rs
+++ b/crates/runtime/src/provider_flow/request_options.rs
@@ -32,41 +32,39 @@ pub(crate) fn normalize_provider_messages(
             .get("role")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("user");
-        if role == "assistant" {
-            if let Some(tool_calls) = message
+        if role == "assistant"
+            && let Some(tool_calls) = message
                 .get("tool_calls")
                 .filter(|value| value.as_array().is_some_and(|calls| !calls.is_empty()))
                 .cloned()
-            {
-                let mut item = serde_json::json!({
-                    "role": "assistant",
-                    "content": message_content_value(&message),
-                    "tool_calls": tool_calls,
-                });
-                if let Some(name) = message.get("name").and_then(serde_json::Value::as_str) {
-                    item["name"] = serde_json::Value::String(name.to_string());
-                }
-                normalized.push(item);
-                continue;
+        {
+            let mut item = serde_json::json!({
+                "role": "assistant",
+                "content": message_content_value(&message),
+                "tool_calls": tool_calls,
+            });
+            if let Some(name) = message.get("name").and_then(serde_json::Value::as_str) {
+                item["name"] = serde_json::Value::String(name.to_string());
             }
+            normalized.push(item);
+            continue;
         }
-        if role == "tool" {
-            if let Some(tool_call_id) = message
+        if role == "tool"
+            && let Some(tool_call_id) = message
                 .get("tool_call_id")
                 .and_then(serde_json::Value::as_str)
                 .filter(|value| !value.trim().is_empty())
-            {
-                let mut item = serde_json::json!({
-                    "role": "tool",
-                    "content": message_content_value(&message),
-                    "tool_call_id": tool_call_id,
-                });
-                if let Some(name) = message.get("name").and_then(serde_json::Value::as_str) {
-                    item["name"] = serde_json::Value::String(name.to_string());
-                }
-                normalized.push(item);
-                continue;
+        {
+            let mut item = serde_json::json!({
+                "role": "tool",
+                "content": message_content_value(&message),
+                "tool_call_id": tool_call_id,
+            });
+            if let Some(name) = message.get("name").and_then(serde_json::Value::as_str) {
+                item["name"] = serde_json::Value::String(name.to_string());
             }
+            normalized.push(item);
+            continue;
         }
         let content = message_content_value(&message);
         if content_is_empty(&content) {
@@ -397,13 +395,49 @@ mod tests {
             .expect("provider flow env lock poisoned");
         let previous: Option<OsString> = std::env::var_os(name);
         match value {
-            Some(value) => std::env::set_var(name, value),
-            None => std::env::remove_var(name),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(name, value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(name)
+                }
+            }
         }
         let result = run();
         match previous {
-            Some(value) => std::env::set_var(name, value),
-            None => std::env::remove_var(name),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(name, value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(name)
+                }
+            }
         }
         result
     }

--- a/crates/runtime/src/router_command_run.rs
+++ b/crates/runtime/src/router_command_run.rs
@@ -356,7 +356,14 @@ mod tests {
     impl EnvGuard {
         fn remove(key: &'static str) -> Self {
             let previous = std::env::var_os(key);
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
             Self { key, previous }
         }
     }
@@ -364,7 +371,14 @@ mod tests {
     impl Drop for EnvGuard {
         fn drop(&mut self) {
             if let Some(previous) = self.previous.take() {
-                std::env::set_var(self.key, previous);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(self.key, previous)
+                };
             }
         }
     }

--- a/crates/runtime/src/runtime/runtime_receive.rs
+++ b/crates/runtime/src/runtime/runtime_receive.rs
@@ -158,10 +158,10 @@ fn extract_text_content(chunk: &serde_json::Value) -> Option<String> {
     if let Some(delta) = chunk.get("delta").and_then(|d| d.as_str()) {
         return Some(delta.to_string());
     }
-    if let Some(delta_obj) = chunk.get("delta").and_then(|d| d.as_object()) {
-        if let Some(text) = delta_obj.get("text").and_then(|t| t.as_str()) {
-            return Some(text.to_string());
-        }
+    if let Some(delta_obj) = chunk.get("delta").and_then(|d| d.as_object())
+        && let Some(text) = delta_obj.get("text").and_then(|t| t.as_str())
+    {
+        return Some(text.to_string());
     }
     None
 }

--- a/crates/runtime/src/runtime_event_writer.rs
+++ b/crates/runtime/src/runtime_event_writer.rs
@@ -534,8 +534,22 @@ mod tests {
         std::fs::create_dir_all(&home).expect("session db home");
         let previous_home = std::env::var_os("TURA_HOME");
         let previous_root = std::env::var_os("SESSION_LOG_DB_ROOT");
-        std::env::set_var("TURA_HOME", &home);
-        std::env::set_var("SESSION_LOG_DB_ROOT", root.path());
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", &home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("SESSION_LOG_DB_ROOT", root.path())
+        };
         let handle = std::thread::spawn(session_log::service::run_socket_service);
         let started = std::time::Instant::now();
         while !session_log_contract::client::service_is_running() {
@@ -763,12 +777,48 @@ mod tests {
         let _ = session_log_contract::client::call_service(&SessionLogCommand::Shutdown);
         let _ = handle.join();
         match previous_home {
-            Some(value) => std::env::set_var("TURA_HOME", value),
-            None => std::env::remove_var("TURA_HOME"),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("TURA_HOME", value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var("TURA_HOME")
+                }
+            }
         }
         match previous_root {
-            Some(value) => std::env::set_var("SESSION_LOG_DB_ROOT", value),
-            None => std::env::remove_var("SESSION_LOG_DB_ROOT"),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var("SESSION_LOG_DB_ROOT", value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var("SESSION_LOG_DB_ROOT")
+                }
+            }
         }
     }
 }

--- a/crates/runtime/src/session_bootstrap/initial_messages.rs
+++ b/crates/runtime/src/session_bootstrap/initial_messages.rs
@@ -220,8 +220,26 @@ mod tests {
         fn drop(&mut self) {
             for (key, value) in &self.keys {
                 match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    Some(value) => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::set_var(key, value)
+                        }
+                    }
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    None => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::remove_var(key)
+                        }
+                    }
                 }
             }
         }
@@ -231,8 +249,22 @@ mod tests {
     fn initial_user_log_preserves_frontend_ids_from_worker_env() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
         let _restore = EnvRestore::capture(&[FRONTEND_MESSAGE_ID_ENV, FRONTEND_PART_ID_ENV]);
-        std::env::set_var(FRONTEND_MESSAGE_ID_ENV, "msg_tui_reopen");
-        std::env::set_var(FRONTEND_PART_ID_ENV, "part_tui_reopen");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(FRONTEND_MESSAGE_ID_ENV, "msg_tui_reopen")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(FRONTEND_PART_ID_ENV, "part_tui_reopen")
+        };
 
         let now = chrono::Utc::now();
         let mut session = SessionManagement::new(

--- a/crates/runtime/src/session_bootstrap/persisted.rs
+++ b/crates/runtime/src/session_bootstrap/persisted.rs
@@ -90,10 +90,10 @@ fn router_addrs_for_current_home() -> Vec<String> {
             addrs.push(addr.to_string());
         }
     }
-    if let Some(addr) = router_addr_from_file() {
-        if !addrs.iter().any(|existing| existing == &addr) {
-            addrs.push(addr);
-        }
+    if let Some(addr) = router_addr_from_file()
+        && !addrs.iter().any(|existing| existing == &addr)
+    {
+        addrs.push(addr);
     }
     addrs
 }
@@ -196,9 +196,30 @@ mod tests {
                 .iter()
                 .map(|key| (*key, std::env::var_os(key)))
                 .collect::<Vec<_>>();
-            std::env::set_var("TURA_HOME", home);
-            std::env::remove_var("SESSION_LOG_DB_ROOT");
-            std::env::remove_var("TURA_DB_ROOT");
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_HOME", home)
+            };
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("SESSION_LOG_DB_ROOT")
+            };
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var("TURA_DB_ROOT")
+            };
             Self { previous }
         }
     }
@@ -207,8 +228,26 @@ mod tests {
         fn drop(&mut self) {
             for (key, value) in self.previous.drain(..) {
                 match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    Some(value) => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::set_var(key, value)
+                        }
+                    }
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    None => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::remove_var(key)
+                        }
+                    }
                 }
             }
         }

--- a/crates/runtime/src/session_bootstrap/prepare_turn.rs
+++ b/crates/runtime/src/session_bootstrap/prepare_turn.rs
@@ -15,15 +15,15 @@ pub(crate) fn bootstrap_orchestration_session(
         crate::workspace_git::ensure_workspace_git_repo(directory)?;
     }
     if let Some(session_id) = gateway_session_id {
-        if let Some(directory) = session_directory.as_ref() {
-            if let Some(mut persisted) = load_persisted_gateway_session(directory, &session_id)? {
-                persisted.prepare_for_new_user_turn(input, now);
-                if let Some(directory) = session_directory {
-                    persisted.session_directory = directory;
-                }
-                persisted.rebind_session_id(session_id);
-                return Ok(persisted);
+        if let Some(directory) = session_directory.as_ref()
+            && let Some(mut persisted) = load_persisted_gateway_session(directory, &session_id)?
+        {
+            persisted.prepare_for_new_user_turn(input, now);
+            if let Some(directory) = session_directory {
+                persisted.session_directory = directory;
             }
+            persisted.rebind_session_id(session_id);
+            return Ok(persisted);
         }
 
         let mut session = create_session_with_topic(input, session_directory)?;

--- a/crates/runtime/src/tool_flow/execute.rs
+++ b/crates/runtime/src/tool_flow/execute.rs
@@ -121,44 +121,44 @@ pub(crate) fn execute_tool_calls(
             results.push(blocked_result);
             continue;
         }
-        if tool_call.tool_name == COMMAND_RUN_TOOL {
-            if let Some(streamed_result) = streamed_command_run_result(runtime) {
-                let mut streamed_result = streamed_result;
-                apply_task_attribution_to_streamed_result(session, &mut streamed_result);
-                record_streamed_command_events(session, runtime, &streamed_result);
-                let streamed_arguments =
-                    streamed_command_run_arguments(&normalized_arguments, &streamed_result);
-                let execution_result = ToolExecutionResult {
-                    tool_name: tool_call.tool_name.clone(),
-                    arguments: streamed_arguments.clone(),
-                    success: command_run_result_success(&streamed_result),
-                    error: command_run_result_error(&streamed_result),
-                    result: streamed_result,
-                };
-                let mut execution_result = execution_result;
-                if apply_tool_result_session_state_update(
-                    session,
-                    &tool_call.tool_name,
-                    &mut execution_result.result,
-                ) {
-                    publish_task_plan_todos(session, publisher);
-                    execution_result.success = command_run_result_success(&execution_result.result);
-                    execution_result.error = command_run_result_error(&execution_result.result);
-                }
-                publish_tool_call_record(
-                    session,
-                    runtime,
-                    &execution_tool_call,
-                    streamed_arguments,
-                    &execution_result.result,
-                    execution_result.success,
-                    execution_result.error.as_deref(),
-                    tool_started_at,
-                    publisher,
-                );
-                results.push(execution_result);
-                continue;
+        if tool_call.tool_name == COMMAND_RUN_TOOL
+            && let Some(streamed_result) = streamed_command_run_result(runtime)
+        {
+            let mut streamed_result = streamed_result;
+            apply_task_attribution_to_streamed_result(session, &mut streamed_result);
+            record_streamed_command_events(session, runtime, &streamed_result);
+            let streamed_arguments =
+                streamed_command_run_arguments(&normalized_arguments, &streamed_result);
+            let execution_result = ToolExecutionResult {
+                tool_name: tool_call.tool_name.clone(),
+                arguments: streamed_arguments.clone(),
+                success: command_run_result_success(&streamed_result),
+                error: command_run_result_error(&streamed_result),
+                result: streamed_result,
+            };
+            let mut execution_result = execution_result;
+            if apply_tool_result_session_state_update(
+                session,
+                &tool_call.tool_name,
+                &mut execution_result.result,
+            ) {
+                publish_task_plan_todos(session, publisher);
+                execution_result.success = command_run_result_success(&execution_result.result);
+                execution_result.error = command_run_result_error(&execution_result.result);
             }
+            publish_tool_call_record(
+                session,
+                runtime,
+                &execution_tool_call,
+                streamed_arguments,
+                &execution_result.result,
+                execution_result.success,
+                execution_result.error.as_deref(),
+                tool_started_at,
+                publisher,
+            );
+            results.push(execution_result);
+            continue;
         }
         let execute_input = ExecuteToolInput {
             tool_name: tool_call.tool_name.clone(),

--- a/crates/runtime/src/tool_flow/task_status.rs
+++ b/crates/runtime/src/tool_flow/task_status.rs
@@ -45,15 +45,14 @@ pub(crate) fn apply_tool_result_session_state_update(
                 .unwrap_or(&[]);
             let previous_tasks = task_plan_snapshot(&task_plan);
             replace_active_task_with_planning(&mut task_plan, steps);
-            if session.auto_session_name {
-                if let Some(summary) = task_plan
+            if session.auto_session_name
+                && let Some(summary) = task_plan
                     .detailed_tasks
                     .iter()
                     .rev()
                     .find_map(|task| non_empty_string(&task.task_summary))
-                {
-                    session.session_name = summary;
-                }
+            {
+                session.session_name = summary;
             }
             activate_first_planned_task_if_needed(&mut task_plan);
             task_topology_log = Some(task_topology_log_entry(&task_plan, steps, previous_tasks));
@@ -163,11 +162,10 @@ fn apply_task_group(
             task.status,
             PlanStatus::Doing | PlanStatus::Todo | PlanStatus::Question
         )
-    }) {
-        if task.task_summary.trim() != group.trim() {
-            task.task_summary = group;
-            changed = true;
-        }
+    }) && task.task_summary.trim() != group.trim()
+    {
+        task.task_summary = group;
+        changed = true;
     }
     changed
 }
@@ -1325,10 +1323,9 @@ mod tests {
             }
             if value.get("type").and_then(serde_json::Value::as_str)
                 == Some(RUNTIME_PROMPT_MANUAL_RECORD_TYPE)
+                && let Some(id) = value.get("task_type").and_then(serde_json::Value::as_str)
             {
-                if let Some(id) = value.get("task_type").and_then(serde_json::Value::as_str) {
-                    ids.push(id.to_string());
-                }
+                ids.push(id.to_string());
             }
         }
         ids.reverse();

--- a/crates/runtime/src/turn_loop/task_progress.rs
+++ b/crates/runtime/src/turn_loop/task_progress.rs
@@ -59,11 +59,11 @@ fn command_run_result_items(result: &serde_json::Value) -> Vec<&serde_json::Valu
     };
     let mut items = Vec::new();
     for item in results {
-        if item.get("mode").and_then(serde_json::Value::as_str) == Some("batch") {
-            if let Some(batch_results) = item.get("results").and_then(serde_json::Value::as_array) {
-                items.extend(batch_results);
-                continue;
-            }
+        if item.get("mode").and_then(serde_json::Value::as_str) == Some("batch")
+            && let Some(batch_results) = item.get("results").and_then(serde_json::Value::as_array)
+        {
+            items.extend(batch_results);
+            continue;
         }
         items.push(item);
     }

--- a/crates/runtime/src/worker.rs
+++ b/crates/runtime/src/worker.rs
@@ -211,15 +211,43 @@ fn handle_call(payload: &Value) -> Value {
     };
 
     if no_op_manual {
-        std::env::set_var("TURA_NO_OP_MANUAL", "1");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_NO_OP_MANUAL", "1")
+        };
     } else {
-        std::env::remove_var("TURA_NO_OP_MANUAL");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_NO_OP_MANUAL")
+        };
     }
 
     if let Some(agent_spec) = agent_spec {
-        std::env::set_var("TURA_ROUTER_AGENT_SPEC", agent_spec.to_string());
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_ROUTER_AGENT_SPEC", agent_spec.to_string())
+        };
     } else {
-        std::env::remove_var("TURA_ROUTER_AGENT_SPEC");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_ROUTER_AGENT_SPEC")
+        };
     }
     match crate::mano::process_from_gateway_session_with_lease_in_directory(
         session_id.clone(),
@@ -384,8 +412,22 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
         let previous_pid = std::env::var_os("TURA_ROUTER_PARENT_PID");
         let previous_start = std::env::var_os("TURA_ROUTER_PARENT_START_TIME");
-        std::env::set_var("TURA_ROUTER_PARENT_PID", "1234");
-        std::env::set_var("TURA_ROUTER_PARENT_START_TIME", "5678");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_ROUTER_PARENT_PID", "1234")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_ROUTER_PARENT_START_TIME", "5678")
+        };
 
         let parent = RouterParentProcess::from_env().expect("parent env");
         assert_eq!(parent.pid, 1234);
@@ -526,9 +568,23 @@ mod tests {
 
     fn restore_env(key: &str, previous: Option<std::ffi::OsString>) {
         if let Some(value) = previous {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         } else {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 }

--- a/crates/runtime/tests/business/checkpoint_ack_flow.rs
+++ b/crates/runtime/tests/business/checkpoint_ack_flow.rs
@@ -527,10 +527,38 @@ impl EnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "20");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "20")
+        };
         Self { previous }
     }
 }
@@ -539,8 +567,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/runtime/tests/business/claude_code_mock_e2e.rs
+++ b/crates/runtime/tests/business/claude_code_mock_e2e.rs
@@ -413,7 +413,14 @@ impl EnvGuard {
             .map(|(key, _)| ((*key).to_string(), std::env::var(key).ok()))
             .collect::<Vec<_>>();
         for (key, value) in values {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         }
         Self { previous }
     }
@@ -423,9 +430,23 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in &self.previous {
             if let Some(value) = value {
-                std::env::set_var(key, value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(key, value)
+                };
             } else {
-                std::env::remove_var(key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(key)
+                };
             }
         }
     }

--- a/crates/runtime/tests/business/coding_agent_mock_e2e.rs
+++ b/crates/runtime/tests/business/coding_agent_mock_e2e.rs
@@ -180,7 +180,10 @@ fn coding_agent_executes_command_run_command_before_stream_finishes() {
             .first_command_observed_before_response_finished
             .load(Ordering::SeqCst),
         "first streamed command did not execute before the provider finished sending the response; requests={:#?}; first_exists={}; second_exists={}",
-        provider.requests.lock().expect("mock provider requests lock"),
+        provider
+            .requests
+            .lock()
+            .expect("mock provider requests lock"),
         workspace.join("streamed-first.txt").exists(),
         workspace.join("streamed-second.txt").exists()
     );

--- a/crates/runtime/tests/business/create_runtime_flow.rs
+++ b/crates/runtime/tests/business/create_runtime_flow.rs
@@ -448,7 +448,14 @@ impl EnvGuard {
         let keys = vars.iter().map(|(key, _)| *key).collect::<Vec<_>>();
         let guard = Self::clear(&keys);
         for (key, value) in vars {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         }
         guard
     }
@@ -458,7 +465,14 @@ impl EnvGuard {
             .iter()
             .map(|key| {
                 let previous = std::env::var_os(key);
-                std::env::remove_var(key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(key)
+                };
                 (*key, previous)
             })
             .collect();
@@ -470,8 +484,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..).rev() {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/runtime/tests/business/helpers/coding_agent_mock.rs
+++ b/crates/runtime/tests/business/helpers/coding_agent_mock.rs
@@ -1120,7 +1120,14 @@ impl EnvGuard {
             .map(|(key, _)| ((*key).to_string(), std::env::var(key).ok()))
             .collect::<Vec<_>>();
         for (key, value) in values {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         }
         Self { previous }
     }
@@ -1130,9 +1137,23 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in &self.previous {
             if let Some(value) = value {
-                std::env::set_var(key, value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(key, value)
+                };
             } else {
-                std::env::remove_var(key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(key)
+                };
             }
         }
     }

--- a/crates/runtime/tests/business/provider_boundary_flow.rs
+++ b/crates/runtime/tests/business/provider_boundary_flow.rs
@@ -1141,7 +1141,14 @@ impl EnvGuard {
             .iter()
             .map(|(key, value)| {
                 let previous = std::env::var_os(key);
-                std::env::set_var(key, value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(key, value)
+                };
                 (*key, previous)
             })
             .collect();
@@ -1153,13 +1160,27 @@ impl EnvGuard {
             .iter()
             .map(|(key, value)| {
                 let previous = std::env::var_os(key);
-                std::env::set_var(key, value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(key, value)
+                };
                 (*key, previous)
             })
             .collect::<Vec<_>>();
         previous.extend(remove.iter().map(|key| {
             let previous = std::env::var_os(key);
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
             (*key, previous)
         }));
         Self { previous }
@@ -1170,8 +1191,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..).rev() {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/runtime/tests/business/provider_timeout_flow.rs
+++ b/crates/runtime/tests/business/provider_timeout_flow.rs
@@ -828,7 +828,14 @@ struct EnvGuard {
 impl EnvGuard {
     fn set(key: &'static str, value: &str) -> Self {
         let previous = std::env::var_os(key);
-        std::env::set_var(key, value);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(key, value)
+        };
         Self { key, previous }
     }
 }
@@ -836,8 +843,26 @@ impl EnvGuard {
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         match self.previous.take() {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(self.key, value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(self.key)
+                }
+            }
         }
     }
 }

--- a/crates/runtime/tests/business/session_log_queue_recovery_flow.rs
+++ b/crates/runtime/tests/business/session_log_queue_recovery_flow.rs
@@ -674,10 +674,38 @@ impl EnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "20");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "20")
+        };
         Self { previous }
     }
 }
@@ -686,8 +714,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/runtime/tests/business/streamed_command_run_flow.rs
+++ b/crates/runtime/tests/business/streamed_command_run_flow.rs
@@ -14,12 +14,26 @@ static MOCK_ROUTER_INIT: Mutex<()> = Mutex::new(());
 
 fn ensure_mock_router() {
     if let Some(addr) = MOCK_ROUTER_ADDR.get() {
-        std::env::set_var("TURA_ROUTER_ADDR", addr);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_ROUTER_ADDR", addr)
+        };
         return;
     }
     let _guard = MOCK_ROUTER_INIT.lock().expect("mock router init lock");
     if let Some(addr) = MOCK_ROUTER_ADDR.get() {
-        std::env::set_var("TURA_ROUTER_ADDR", addr);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_ROUTER_ADDR", addr)
+        };
         return;
     }
 
@@ -53,7 +67,14 @@ fn ensure_mock_router() {
     MOCK_ROUTER_ADDR
         .set(addr.clone())
         .expect("mock router addr set once");
-    std::env::set_var("TURA_ROUTER_ADDR", addr);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_ROUTER_ADDR", addr)
+    };
 }
 
 async fn mock_router_response(raw: &str) -> Value {

--- a/crates/runtime/tests/child_dispatch_test.rs
+++ b/crates/runtime/tests/child_dispatch_test.rs
@@ -30,18 +30,60 @@ fn env_lock() -> MutexGuard<'static, ()> {
 }
 
 fn reset_mock_env() {
-    std::env::set_var("TURA_ROUTER_BIN", mock_router_bin());
-    std::env::set_var("TURA_ALLOW_CHILD_ROUTER_CLI_FOR_TEST", "1");
-    std::env::remove_var("MOCK_RECURSE_TO_DEPTH");
-    std::env::remove_var("MOCK_AGENT_SUMMARY");
-    std::env::remove_var("MOCK_FAIL");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_ROUTER_BIN", mock_router_bin())
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_ALLOW_CHILD_ROUTER_CLI_FOR_TEST", "1")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("MOCK_RECURSE_TO_DEPTH")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("MOCK_AGENT_SUMMARY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("MOCK_FAIL")
+    };
 }
 
 #[test]
 fn single_child_dispatch_returns_summary() {
     let _guard = env_lock();
     reset_mock_env();
-    std::env::set_var("MOCK_AGENT_SUMMARY", "solo-summary");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("MOCK_AGENT_SUMMARY", "solo-summary")
+    };
 
     let result = dispatch_child_agent(&ChildAgentRequest {
         agent: "solo".to_string(),
@@ -88,10 +130,7 @@ fn concurrent_dispatch_returns_both_summaries() {
 
     let agents: Vec<String> = results
         .iter()
-        .map(|r| {
-            let summary = r.as_ref().expect("ok").clone_summary();
-            summary
-        })
+        .map(|r| r.as_ref().expect("ok").clone_summary())
         .collect();
     assert!(agents.iter().any(|s| s.contains("agentA")));
     assert!(agents.iter().any(|s| s.contains("agentB")));
@@ -102,8 +141,22 @@ fn recursive_dispatch_2_levels_returns_one_summary() {
     let _guard = env_lock();
     reset_mock_env();
     // Top-level agent at depth=1 recurses to depth=2 and folds the grandchild summary back in.
-    std::env::set_var("MOCK_RECURSE_TO_DEPTH", "2");
-    std::env::set_var("MOCK_AGENT_SUMMARY", "lead-summary");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("MOCK_RECURSE_TO_DEPTH", "2")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("MOCK_AGENT_SUMMARY", "lead-summary")
+    };
 
     let result = dispatch_child_agent(&ChildAgentRequest {
         agent: "lead".to_string(),

--- a/crates/runtime/tests/live/claude_code_live_e2e.rs
+++ b/crates/runtime/tests/live/claude_code_live_e2e.rs
@@ -211,7 +211,14 @@ impl EnvGuard {
             .map(|(key, _)| ((*key).to_string(), std::env::var(key).ok()))
             .collect::<Vec<_>>();
         for (key, value) in values {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         }
         Self { previous }
     }
@@ -221,9 +228,23 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in &self.previous {
             if let Some(value) = value {
-                std::env::set_var(key, value);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(key, value)
+                };
             } else {
-                std::env::remove_var(key);
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(key)
+                };
             }
         }
     }

--- a/crates/runtime/tests/performance/session_log_queue_pressure_test.rs
+++ b/crates/runtime/tests/performance/session_log_queue_pressure_test.rs
@@ -321,10 +321,38 @@ impl EnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
-        std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "20");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", "20")
+        };
         Self { previous }
     }
 }
@@ -333,8 +361,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/runtime/tests/performance/streamed_command_run_pressure_test.rs
+++ b/crates/runtime/tests/performance/streamed_command_run_pressure_test.rs
@@ -283,8 +283,26 @@ impl EnvGuard {
     fn set(key: &'static str, value: Option<String>) -> Self {
         let previous = std::env::var_os(key);
         match value {
-            Some(value) => std::env::set_var(key, value),
-            None => std::env::remove_var(key),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(key, value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(key)
+                }
+            }
         }
         Self { key, previous }
     }
@@ -293,8 +311,26 @@ impl EnvGuard {
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         match self.previous.take() {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            Some(value) => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::set_var(self.key, value)
+                }
+            }
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            None => {
+                #[allow(
+                    unsafe_code,
+                    reason = "Rust 2024 process-environment mutation audited at the caller"
+                )]
+                unsafe {
+                    std::env::remove_var(self.key)
+                }
+            }
         }
     }
 }

--- a/crates/runtime/tests/support/session_db_support.rs
+++ b/crates/runtime/tests/support/session_db_support.rs
@@ -14,9 +14,30 @@ impl SessionDbTestService {
         let root = tempfile::tempdir().expect("session_db root");
         let home = root.path().join("home");
         std::fs::create_dir_all(&home).expect("session_db home");
-        std::env::set_var("TURA_HOME", &home);
-        std::env::set_var("SESSION_LOG_DB_ROOT", root.path());
-        std::env::remove_var("TURA_DB_ROOT");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", &home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("SESSION_LOG_DB_ROOT", root.path())
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
 
         let handle = std::thread::spawn(session_log::service::run_socket_service);
         let started = std::time::Instant::now();
@@ -76,8 +97,26 @@ impl Drop for EnvRestore {
     fn drop(&mut self) {
         for (key, value) in &self.previous {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/session_log/src/bin/tura_session_db.rs
+++ b/crates/session_log/src/bin/tura_session_db.rs
@@ -6,6 +6,13 @@
 
 fn main() -> anyhow::Result<()> {
     tura_path::process_hardening::harden_current_process("session_db");
-    std::env::set_var("TURA_ROLE", "session_db");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_ROLE", "session_db")
+    };
     session_log::service::run_socket_service()
 }

--- a/crates/session_log/src/ipc.rs
+++ b/crates/session_log/src/ipc.rs
@@ -123,12 +123,10 @@ pub(crate) fn execute_command_with_feed(
             if matches!(
                 &result,
                 session_log_contract::RuntimeRegistrationOutcome::Registered { .. }
-            ) {
-                if let Some(entry) =
-                    store.session_feed_entry_by_event_id(&runtime_id, &projection_event_id)?
-                {
-                    committed_feed_entries.push(entry);
-                }
+            ) && let Some(entry) =
+                store.session_feed_entry_by_event_id(&runtime_id, &projection_event_id)?
+            {
+                committed_feed_entries.push(entry);
             }
             SessionLogResponse::RuntimeRegistered { result }
         }
@@ -145,12 +143,10 @@ pub(crate) fn execute_command_with_feed(
                 &result,
                 session_log_contract::RuntimeEventCommitOutcome::Applied { projection, .. }
                     if projection.state.is_terminal()
-            ) {
-                if let Some(entry) =
-                    store.session_feed_entry_by_event_id(&runtime_id, &projection_event_id)?
-                {
-                    committed_feed_entries.push(entry);
-                }
+            ) && let Some(entry) =
+                store.session_feed_entry_by_event_id(&runtime_id, &projection_event_id)?
+            {
+                committed_feed_entries.push(entry);
             }
             SessionLogResponse::RuntimeEventCommitted { result }
         }
@@ -446,8 +442,26 @@ mod tests {
                 .collect::<Vec<_>>();
             for (key, value) in values {
                 match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    Some(value) => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::set_var(key, value)
+                        }
+                    }
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    None => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::remove_var(key)
+                        }
+                    }
                 }
             }
             Self { previous }
@@ -458,8 +472,26 @@ mod tests {
         fn drop(&mut self) {
             for (key, value) in &self.previous {
                 match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    Some(value) => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::set_var(key, value)
+                        }
+                    }
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    None => {
+                        #[allow(
+                            unsafe_code,
+                            reason = "Rust 2024 process-environment mutation audited at the caller"
+                        )]
+                        unsafe {
+                            std::env::remove_var(key)
+                        }
+                    }
                 }
             }
         }
@@ -903,12 +935,35 @@ mod tests {
         fn set(connect_ms: &str, response_ms: Option<&str>) -> Self {
             let previous_connect = std::env::var_os("TURA_SESSION_DB_PROBE_TIMEOUT_MS");
             let previous_response = std::env::var_os("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS");
-            std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", connect_ms);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", connect_ms)
+            };
             match response_ms {
                 Some(value) => {
-                    std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", value)
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", value)
+                    }
                 }
-                None => std::env::remove_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS"),
+                None => {
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS")
+                    }
+                }
             }
             Self {
                 previous_connect,
@@ -920,14 +975,48 @@ mod tests {
     impl Drop for ProbeEnvGuard {
         fn drop(&mut self) {
             match &self.previous_connect {
-                Some(value) => std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", value),
-                None => std::env::remove_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS"),
+                Some(value) => {
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS", value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var("TURA_SESSION_DB_PROBE_TIMEOUT_MS")
+                    }
+                }
             }
             match &self.previous_response {
                 Some(value) => {
-                    std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", value)
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS", value)
+                    }
                 }
-                None => std::env::remove_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS"),
+                None => {
+                    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var("TURA_SESSION_DB_PROBE_RESPONSE_TIMEOUT_MS")
+                    }
+                }
             }
         }
     }

--- a/crates/session_log/src/lib.rs
+++ b/crates/session_log/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::unwrap_used)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 pub mod cli;
 pub mod file_queue;

--- a/crates/session_log/src/store/runtime_events.rs
+++ b/crates/session_log/src/store/runtime_events.rs
@@ -282,13 +282,13 @@ impl SessionLogStore {
                     return Ok(RuntimeEventCommitOutcome::InvalidEvent {
                         error: "runtime_created session_id does not match registered session"
                             .to_string(),
-                    })
+                    });
                 }
                 Ok(_) => {
                     return Ok(RuntimeEventCommitOutcome::InvalidEvent {
                         error: "runtime_created fallback_from_id does not match registered runtime"
                             .to_string(),
-                    })
+                    });
                 }
                 Err(error) => return Ok(RuntimeEventCommitOutcome::InvalidEvent { error }),
             };

--- a/crates/session_log/src/store/session_commands.rs
+++ b/crates/session_log/src/store/session_commands.rs
@@ -171,8 +171,8 @@ impl SessionLogStore {
                     next_sequence += 1;
                     inserted_context = true;
                 }
-                if inserted_context {
-                    if let Some(projection) = entry.projection {
+                if inserted_context
+                    && let Some(projection) = entry.projection {
                         let (inserted, projection) =
                             upsert_delta_projection(&tx, &session_id, projection)?;
                         inserted_messages += inserted;
@@ -195,7 +195,6 @@ impl SessionLogStore {
                             event,
                         });
                     }
-                }
             }
             if !management_replay && retained_from_sequence < row.retained_from_sequence {
                 anyhow::bail!(
@@ -380,14 +379,13 @@ impl SessionLogStore {
         management.use_last_tool_call_response = request.use_last_tool_call_response;
         management.disable_permission_restrictions = request.disable_permission_restrictions;
         management.replace_lifecycle_projection(projection.clone());
-        if request.auto_session_name {
-            if let Some(name) = request
+        if request.auto_session_name
+            && let Some(name) = request
                 .initial_task_plan_patch
                 .as_ref()
                 .and_then(task_plan_patch_summary_for_auto_name)
-            {
-                management.session_name = name;
-            }
+        {
+            management.session_name = name;
         }
         let metadata = SessionMetadata {
             session_directory: request.session_directory.clone(),
@@ -838,14 +836,14 @@ impl SessionLogStore {
                 })?;
             let updated_at = row.updated_at.max(now_ms);
             apply_metadata_patch(&mut management, &mut metadata, &request.metadata);
-            if request.metadata.name.is_none() && management.auto_session_name {
-                if let Some(name) = request
+            if request.metadata.name.is_none()
+                && management.auto_session_name
+                && let Some(name) = request
                     .task_plan_patch
                     .as_ref()
                     .and_then(task_plan_patch_summary_for_auto_name)
-                {
-                    management.session_name = name;
-                }
+            {
+                management.session_name = name;
             }
             management.session_last_update_at =
                 chrono::DateTime::<chrono::Utc>::from_timestamp_millis(updated_at)
@@ -1514,15 +1512,14 @@ fn persist_command_message_projection(
             management.record_user_message_at(message_at);
         }
         if inserted > 0 {
-            if management.input.user_input.trim().is_empty() {
-                if let Some(text) = projection
+            if management.input.user_input.trim().is_empty()
+                && let Some(text) = projection
                     .record
                     .get("parts")
                     .and_then(Value::as_array)
                     .and_then(|parts| parts.iter().find_map(|part| part.get("text")?.as_str()))
-                {
-                    management.input.user_input = text.to_string();
-                }
+            {
+                management.input.user_input = text.to_string();
             }
             management
                 .session_log

--- a/crates/session_log/tests/os_testing/process_lifecycle_e2e.rs
+++ b/crates/session_log/tests/os_testing/process_lifecycle_e2e.rs
@@ -355,9 +355,30 @@ impl EnvGuard {
             .iter()
             .map(|key| (*key, std::env::var_os(key)))
             .collect::<Vec<_>>();
-        std::env::set_var("TURA_HOME", home);
-        std::env::remove_var("SESSION_LOG_DB_ROOT");
-        std::env::remove_var("TURA_DB_ROOT");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("SESSION_LOG_DB_ROOT")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
         Self { previous }
     }
 }
@@ -366,8 +387,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..) {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/session_log/tests/os_testing/process_management_test.rs
+++ b/crates/session_log/tests/os_testing/process_management_test.rs
@@ -44,8 +44,26 @@ impl Drop for EnvRestore {
     fn drop(&mut self) {
         for (key, value) in &self.keys {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }
@@ -82,8 +100,22 @@ fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
 /// same db root so `session_log::ipc` resolves the same endpoint file.
 fn start_service(db_root: &Path) -> ServiceGuard {
     let env = EnvRestore::capture(&["SESSION_LOG_DB_ROOT", "TURA_DB_ROOT"]);
-    std::env::set_var("SESSION_LOG_DB_ROOT", db_root);
-    std::env::remove_var("TURA_DB_ROOT");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("SESSION_LOG_DB_ROOT", db_root)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_DB_ROOT")
+    };
 
     let child = Command::new(SESSION_DB_BIN)
         .env("SESSION_LOG_DB_ROOT", db_root)

--- a/crates/session_log/tests/os_testing/router_adopts_live_session_db_flow.rs
+++ b/crates/session_log/tests/os_testing/router_adopts_live_session_db_flow.rs
@@ -452,8 +452,26 @@ impl EnvGuard {
             .collect::<Vec<_>>();
         for (key, value) in values {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
         Self { previous }
@@ -464,8 +482,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..).rev() {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/session_log/tests/os_testing/session_db_discards_dirty_queue_flow.rs
+++ b/crates/session_log/tests/os_testing/session_db_discards_dirty_queue_flow.rs
@@ -322,8 +322,26 @@ impl EnvGuard {
             .collect::<Vec<_>>();
         for (key, value) in values {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
         Self { previous }
@@ -334,8 +352,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..).rev() {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/crates/session_log/tests/performance/store_concurrency_test.rs
+++ b/crates/session_log/tests/performance/store_concurrency_test.rs
@@ -36,8 +36,26 @@ impl Drop for EnvRestore {
     fn drop(&mut self) {
         for (key, value) in &self.keys {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }
@@ -56,8 +74,22 @@ impl DirectDbGuard {
         let env = EnvRestore::capture(&["SESSION_LOG_DB_ROOT", "TURA_DB_ROOT"]);
         let root = tempfile::tempdir().expect("tempdir");
         let workspaces = tempfile::tempdir().expect("workspace tempdir");
-        std::env::set_var("SESSION_LOG_DB_ROOT", root.path());
-        std::env::remove_var("TURA_DB_ROOT");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("SESSION_LOG_DB_ROOT", root.path())
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
         Self {
             _serial: serial,
             _env: env,

--- a/crates/session_log/tests/store_test.rs
+++ b/crates/session_log/tests/store_test.rs
@@ -40,8 +40,26 @@ impl Drop for EnvRestore {
     fn drop(&mut self) {
         for (key, value) in &self.keys {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }
@@ -60,8 +78,22 @@ impl DirectDbGuard {
         let env = EnvRestore::capture(&["SESSION_LOG_DB_ROOT", "TURA_DB_ROOT"]);
         let root = tempfile::tempdir().expect("tempdir");
         let workspaces = tempfile::tempdir().expect("workspace tempdir");
-        std::env::set_var("SESSION_LOG_DB_ROOT", root.path());
-        std::env::remove_var("TURA_DB_ROOT");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("SESSION_LOG_DB_ROOT", root.path())
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
         Self {
             _serial: serial,
             _env: env,

--- a/crates/session_log_contract/src/client.rs
+++ b/crates/session_log_contract/src/client.rs
@@ -299,7 +299,7 @@ pub fn unreachable_owner_lock_message() -> Option<String> {
                 &path,
                 read_owner_lock_record(&path).as_ref(),
                 &error.to_string(),
-            ))
+            ));
         }
     };
     match file.try_lock_exclusive() {

--- a/crates/tools/src/command_run/handler.rs
+++ b/crates/tools/src/command_run/handler.rs
@@ -610,15 +610,15 @@ async fn run_command_run_item(
             );
         }
     };
-    if sandbox {
-        if let Err(message) = validate_command_sandbox(&command_name, &call, &ctx.session_dir) {
-            return CommandRunItemResult::blocked(
-                command.index,
-                command.effective_step(),
-                command_name,
-                message,
-            );
-        }
+    if sandbox
+        && let Err(message) = validate_command_sandbox(&command_name, &call, &ctx.session_dir)
+    {
+        return CommandRunItemResult::blocked(
+            command.index,
+            command.effective_step(),
+            command_name,
+            message,
+        );
     }
     match router.dispatch(call, ctx, force_exclusive).await {
         Ok(result) => CommandRunItemResult {

--- a/crates/tools/src/command_run/handler_parse.rs
+++ b/crates/tools/src/command_run/handler_parse.rs
@@ -180,10 +180,10 @@ fn inline_command_arguments(object: &serde_json::Map<String, Value>) -> Option<V
 
 fn parse_jsonish_value(text: &str) -> Result<Value, serde_json::Error> {
     let trimmed = text.trim();
-    if let Some(unfenced) = strip_json_code_fence(trimmed) {
-        if let Ok(value) = serde_json::from_str(unfenced.trim()) {
-            return Ok(value);
-        }
+    if let Some(unfenced) = strip_json_code_fence(trimmed)
+        && let Ok(value) = serde_json::from_str(unfenced.trim())
+    {
+        return Ok(value);
     }
     serde_json::from_str(trimmed)
 }

--- a/crates/tools/src/commands/apply_patch/mod.rs
+++ b/crates/tools/src/commands/apply_patch/mod.rs
@@ -261,10 +261,10 @@ pub fn access(patch_text: &str, session_dir: &Path) -> Access {
                     if let Some(key) = lock_key(session_dir, &change.path) {
                         keys.push(key);
                     }
-                    if let Some(move_path) = change.move_path.as_deref() {
-                        if let Some(key) = lock_key(session_dir, move_path) {
-                            keys.push(key);
-                        }
+                    if let Some(move_path) = change.move_path.as_deref()
+                        && let Some(key) = lock_key(session_dir, move_path)
+                    {
+                        keys.push(key);
                     }
                     keys
                 })
@@ -456,10 +456,10 @@ fn finish_change(
     current: &mut Option<PatchChange>,
     hunk: &mut Option<Vec<String>>,
 ) {
-    if let Some(hunk_lines) = hunk.take() {
-        if let Some(change) = current.as_mut() {
-            change.hunks.push(hunk_lines);
-        }
+    if let Some(hunk_lines) = hunk.take()
+        && let Some(change) = current.as_mut()
+    {
+        change.hunks.push(hunk_lines);
     }
     if let Some(change) = current.take() {
         changes.push(change);
@@ -548,7 +548,7 @@ fn apply_change(change: &PatchChange, session_dir: &Path) -> Result<Value, Patch
                 kind: "ParseError",
                 message: format!("unsupported patch change kind: {}", change.kind),
                 failed_change: Some(patch_change_value(change)),
-            })
+            });
         }
     }
     Ok(patch_change_value(change))
@@ -744,7 +744,9 @@ fn apply_patch_failure_guidance(kind: &str, partial: bool) -> &'static str {
         ("ContextMismatch", false) => {
             "apply_patch failed because expected context was not found; read the current file and retry with a smaller hunk."
         }
-        (_, true) => "apply_patch failed after earlier changes were applied; inspect changes before retrying.",
+        (_, true) => {
+            "apply_patch failed after earlier changes were applied; inspect changes before retrying."
+        }
         _ => "apply_patch failed; inspect error_type and message before retrying.",
     }
 }

--- a/crates/tools/src/commands/apply_patch/tests/mod.rs
+++ b/crates/tools/src/commands/apply_patch/tests/mod.rs
@@ -39,9 +39,9 @@ fn update_file_matches_lf_patch_against_crlf_file_and_preserves_crlf() {
     fs::write(root.join("app.txt"), "alpha\r\nold\r\nomega\r\n").expect("fixture");
 
     let result = execute(
-            "*** Begin Patch\n*** Update File: app.txt\n@@\n alpha\n-old\n+new\n omega\n*** End Patch\n",
-            &root,
-        );
+        "*** Begin Patch\n*** Update File: app.txt\n@@\n alpha\n-old\n+new\n omega\n*** End Patch\n",
+        &root,
+    );
 
     assert!(result.success, "{}", result.stderr);
     assert_eq!(
@@ -57,9 +57,9 @@ fn update_file_tolerates_trailing_whitespace_context_mismatch() {
     fs::write(root.join("app.txt"), "alpha  \nold\t\nomega\n").expect("fixture");
 
     let result = execute(
-            "*** Begin Patch\n*** Update File: app.txt\n@@\n alpha\n-old\n+new\n omega\n*** End Patch\n",
-            &root,
-        );
+        "*** Begin Patch\n*** Update File: app.txt\n@@\n alpha\n-old\n+new\n omega\n*** End Patch\n",
+        &root,
+    );
 
     assert!(result.success, "{}", result.stderr);
     assert_eq!(
@@ -75,9 +75,9 @@ fn update_file_tolerates_normalized_unicode_punctuation_context() {
     fs::write(root.join("app.txt"), "say “hello”\nold – value\n").expect("fixture");
 
     let result = execute(
-            "*** Begin Patch\n*** Update File: app.txt\n@@\n say \"hello\"\n-old - value\n+new - value\n*** End Patch\n",
-            &root,
-        );
+        "*** Begin Patch\n*** Update File: app.txt\n@@\n say \"hello\"\n-old - value\n+new - value\n*** End Patch\n",
+        &root,
+    );
 
     assert!(result.success, "{}", result.stderr);
     assert_eq!(
@@ -93,9 +93,9 @@ fn update_file_applies_multiple_hunks_without_position_shift() {
     fs::write(root.join("app.txt"), "one\nold-a\nmiddle\nold-b\nend\n").expect("fixture");
 
     let result = execute(
-            "*** Begin Patch\n*** Update File: app.txt\n@@\n-old-a\n+new-a\n@@\n-old-b\n+new-b\n*** End Patch\n",
-            &root,
-        );
+        "*** Begin Patch\n*** Update File: app.txt\n@@\n-old-a\n+new-a\n@@\n-old-b\n+new-b\n*** End Patch\n",
+        &root,
+    );
 
     assert!(result.success, "{}", result.stderr);
     assert_eq!(
@@ -113,9 +113,9 @@ fn failed_middle_file_reports_successes_and_failures_separately() {
     fs::write(root.join("third.txt"), "old\n").expect("third");
 
     let result = execute(
-            "*** Begin Patch\n*** Update File: first.txt\n@@\n-old\n+new\n*** Update File: second.txt\n@@\n-missing\n+value\n*** Update File: third.txt\n@@\n-old\n+new\n*** End Patch\n",
-            &root,
-        );
+        "*** Begin Patch\n*** Update File: first.txt\n@@\n-old\n+new\n*** Update File: second.txt\n@@\n-missing\n+value\n*** Update File: third.txt\n@@\n-old\n+new\n*** End Patch\n",
+        &root,
+    );
 
     assert!(!result.success);
     assert_eq!(result.output["error_type"], json!("ContextMismatch"));

--- a/crates/tools/src/commands/command_safety.rs
+++ b/crates/tools/src/commands/command_safety.rs
@@ -209,15 +209,15 @@ fn check_segment(segment: &str, depth: usize, context: Option<&SafetyContext>) -
     let args = &tokens[1..];
 
     // `bash`/`zsh`/`sh -c "<script>"` indirection.
-    if NESTED_SHELLS.contains(&base.as_str()) {
-        if let Some(script) = nested_shell_script(args) {
-            return scan(&script, depth + 1, context);
-        }
+    if NESTED_SHELLS.contains(&base.as_str())
+        && let Some(script) = nested_shell_script(args)
+    {
+        return scan(&script, depth + 1, context);
     }
-    if base == "cmd" {
-        if let Some(script) = nested_cmd_script(args) {
-            return scan(&script, depth + 1, context);
-        }
+    if base == "cmd"
+        && let Some(script) = nested_cmd_script(args)
+    {
+        return scan(&script, depth + 1, context);
     }
     if POWERSHELL_SHELLS.contains(&base.as_str()) {
         if has_encoded_powershell_command(args) {
@@ -619,15 +619,14 @@ fn collect_shell_variable_assignments(segments: &[String]) -> HashMap<String, St
             continue;
         }
         for token in assignment_tokens {
-            if let Some((name, value)) = token.split_once('=') {
-                if !name.is_empty()
-                    && name
-                        .chars()
-                        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
-                    && !value.trim().is_empty()
-                {
-                    variables.insert(name.to_string(), value.trim().to_string());
-                }
+            if let Some((name, value)) = token.split_once('=')
+                && !name.is_empty()
+                && name
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+                && !value.trim().is_empty()
+            {
+                variables.insert(name.to_string(), value.trim().to_string());
             }
         }
     }
@@ -824,10 +823,11 @@ fn powershell_removal_targets(args: &[String]) -> Vec<String> {
             continue;
         }
         if arg.starts_with('-') {
-            if let Some((name, value)) = lower.split_once(':') {
-                if matches!(name, "path" | "literalpath") && !value.is_empty() {
-                    targets.extend(split_powershell_target_list(value));
-                }
+            if let Some((name, value)) = lower.split_once(':')
+                && matches!(name, "path" | "literalpath")
+                && !value.is_empty()
+            {
+                targets.extend(split_powershell_target_list(value));
             }
             index += 1;
             continue;

--- a/crates/tools/src/commands/task_status/mod.rs
+++ b/crates/tools/src/commands/task_status/mod.rs
@@ -37,10 +37,10 @@ pub fn normalize_output(
     };
     let status = string_field(object, &["status", "task_status"])
         .map(|status| status.trim().to_ascii_lowercase().replace('-', "_"));
-    if let Some(status) = status.as_deref() {
-        if !matches!(status, "doing" | "question" | "done") {
-            return Err("task_status status must be doing, question, or done".to_string());
-        }
+    if let Some(status) = status.as_deref()
+        && !matches!(status, "doing" | "question" | "done")
+    {
+        return Err("task_status status must be doing, question, or done".to_string());
     }
     let task_group = string_field(object, &["task_group"]);
     let task_type = task_type_field(object, "task_type")?;
@@ -205,15 +205,15 @@ fn runtime_prompt_root_candidates() -> Vec<PathBuf> {
     if let Some(project_root) = std::env::var_os("TURA_PROJECT_ROOT") {
         roots.push(runtime_prompt_root_from_repo(PathBuf::from(project_root)));
     }
-    if let Ok(current_dir) = std::env::current_dir() {
-        if let Some(repo_root) = repo_root_from(&current_dir) {
-            roots.push(runtime_prompt_root_from_repo(repo_root));
-        }
+    if let Ok(current_dir) = std::env::current_dir()
+        && let Some(repo_root) = repo_root_from(&current_dir)
+    {
+        roots.push(runtime_prompt_root_from_repo(repo_root));
     }
-    if let Ok(current_exe) = std::env::current_exe() {
-        if let Some(repo_root) = repo_root_from(&current_exe) {
-            roots.push(runtime_prompt_root_from_repo(repo_root));
-        }
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(repo_root) = repo_root_from(&current_exe)
+    {
+        roots.push(runtime_prompt_root_from_repo(repo_root));
     }
     let tools_crate = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     if let Some(crates_dir) = tools_crate.parent() {

--- a/crates/tools/src/external/client.rs
+++ b/crates/tools/src/external/client.rs
@@ -73,10 +73,10 @@ pub fn resolve_binary_in_root(repo_root: &std::path::Path, binary_name: &str) ->
 /// checked before the source-tree `target/{release,debug}` layout used in dev.
 pub fn binary_candidates(repo_root: &std::path::Path, exe_name: &str) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
-    if let Ok(current_exe) = std::env::current_exe() {
-        if let Some(dir) = current_exe.parent() {
-            candidates.push(dir.join(exe_name));
-        }
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(dir) = current_exe.parent()
+    {
+        candidates.push(dir.join(exe_name));
     }
     if let Some(root) = std::env::var_os("TURA_PROJECT_ROOT").map(PathBuf::from) {
         candidates.push(root.join("bin").join(exe_name));
@@ -92,10 +92,10 @@ pub fn binary_candidates(repo_root: &std::path::Path, exe_name: &str) -> Vec<Pat
 }
 
 pub fn repo_root() -> Option<PathBuf> {
-    if let Some(root) = std::env::var_os("TURA_PROJECT_ROOT").map(PathBuf::from) {
-        if root.exists() {
-            return Some(root);
-        }
+    if let Some(root) = std::env::var_os("TURA_PROJECT_ROOT").map(PathBuf::from)
+        && root.exists()
+    {
+        return Some(root);
     }
     std::env::current_dir().ok().and_then(|current| {
         current

--- a/crates/tools/src/runtime/tool.rs
+++ b/crates/tools/src/runtime/tool.rs
@@ -787,22 +787,57 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
         let previous_force = std::env::var_os("TURA_FORCE_PLANNING");
         let previous_execute = std::env::var_os("TURA_FORCE_EXECUTE_TOOLS_PLANNING");
-        std::env::remove_var("TURA_FORCE_PLANNING");
-        std::env::remove_var("TURA_FORCE_EXECUTE_TOOLS_PLANNING");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_FORCE_PLANNING")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_FORCE_EXECUTE_TOOLS_PLANNING")
+        };
         let router = CommandRouter::new();
         assert_eq!(router.resolve_command_tool_name("planning"), None);
         assert!(router.handler("planning").is_none());
 
         for value in ["1", "true", "yes", "on", " TRUE "] {
-            std::env::set_var("TURA_FORCE_PLANNING", value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var("TURA_FORCE_PLANNING", value)
+            };
             assert_eq!(
                 router.resolve_command_tool_name("planning"),
                 Some("planning".to_string())
             );
             assert!(router.handler("planning").is_some());
         }
-        std::env::set_var("TURA_FORCE_PLANNING", "false");
-        std::env::set_var("TURA_FORCE_EXECUTE_TOOLS_PLANNING", "yes");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_FORCE_PLANNING", "false")
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_FORCE_EXECUTE_TOOLS_PLANNING", "yes")
+        };
         assert_eq!(
             router.resolve_command_tool_name("planning"),
             Some("planning".to_string())
@@ -923,9 +958,23 @@ mod tests {
 
     fn restore_env(key: &str, previous: Option<std::ffi::OsString>) {
         if let Some(value) = previous {
-            std::env::set_var(key, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(key, value)
+            };
         } else {
-            std::env::remove_var(key);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(key)
+            };
         }
     }
 

--- a/crates/tools/src/shell_executor/execution.rs
+++ b/crates/tools/src/shell_executor/execution.rs
@@ -261,10 +261,10 @@ pub(super) async fn run_tokio_command_with_timeout(
             }
         }
     };
-    if status.is_some() {
-        if let Some(scope) = scope.take() {
-            retain_shell_process_scope(scope);
-        }
+    if status.is_some()
+        && let Some(scope) = scope.take()
+    {
+        retain_shell_process_scope(scope);
     }
     if status.is_none() {
         wait_task.abort();

--- a/crates/tools/src/shell_executor/mod.rs
+++ b/crates/tools/src/shell_executor/mod.rs
@@ -268,9 +268,23 @@ mod tests {
 
     fn restore_env(name: &str, value: Option<OsString>) {
         if let Some(value) = value {
-            std::env::set_var(name, value);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::set_var(name, value)
+            };
         } else {
-            std::env::remove_var(name);
+            // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+            #[allow(
+                unsafe_code,
+                reason = "Rust 2024 process-environment mutation audited at the caller"
+            )]
+            unsafe {
+                std::env::remove_var(name)
+            };
         }
     }
 
@@ -553,7 +567,14 @@ mod tests {
     async fn async_shell_executor_injects_updated_dotenv_values() {
         let previous_env_path = std::env::var_os("TURA_ENV_PATH");
         let previous_key = std::env::var_os("TURA_SHELL_DOTENV_TEST_KEY");
-        std::env::remove_var("TURA_SHELL_DOTENV_TEST_KEY");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_SHELL_DOTENV_TEST_KEY")
+        };
         let root = std::env::temp_dir().join(format!(
             "tura-shell-dotenv-{}-{}",
             std::process::id(),
@@ -566,7 +587,14 @@ mod tests {
         let env_path = root.join(".env");
         std::fs::write(&env_path, "TURA_SHELL_DOTENV_TEST_KEY=first\n")
             .expect("write first dotenv");
-        std::env::set_var("TURA_ENV_PATH", &env_path);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_ENV_PATH", &env_path)
+        };
 
         let context = ToolContext::new(std::env::current_dir().expect("current dir"));
         let first = execute_async(
@@ -640,14 +668,21 @@ mod tests {
     #[test]
     fn zsh_surface_returns_clear_failure_when_configured_binary_is_missing() {
         let previous = std::env::var_os("TURA_ZSH_PATH");
-        std::env::set_var(
-            "TURA_ZSH_PATH",
-            if cfg!(windows) {
-                r"C:\definitely\missing\tura-zsh.exe"
-            } else {
-                "/definitely/missing/tura-zsh"
-            },
-        );
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(
+                "TURA_ZSH_PATH",
+                if cfg!(windows) {
+                    r"C:\definitely\missing\tura-zsh.exe"
+                } else {
+                    "/definitely/missing/tura-zsh"
+                },
+            )
+        };
 
         let response = super::execute(
             r#"{"command":"print -r -- zsh-ok","timeout_ms":1000}"#,

--- a/crates/tools/src/shell_executor/request.rs
+++ b/crates/tools/src/shell_executor/request.rs
@@ -14,43 +14,41 @@ pub(super) fn parse_shell_request(
     default_timeout_secs: u64,
 ) -> ShellRequest {
     let text = command_line.trim();
-    if text.starts_with('{') || text.starts_with('"') || text.starts_with('\'') {
-        if let Some(value) = parse_shell_request_json(text) {
-            if let Some(command) = value
-                .get("command")
-                .or_else(|| value.get("cmd"))
-                .and_then(Value::as_str)
-            {
-                let timeout_secs = value
-                    .get("timeout_secs")
+    if (text.starts_with('{') || text.starts_with('"') || text.starts_with('\''))
+        && let Some(value) = parse_shell_request_json(text)
+        && let Some(command) = value
+            .get("command")
+            .or_else(|| value.get("cmd"))
+            .and_then(Value::as_str)
+    {
+        let timeout_secs = value
+            .get("timeout_secs")
+            .and_then(Value::as_u64)
+            .or_else(|| {
+                value
+                    .get("timeout_ms")
                     .and_then(Value::as_u64)
-                    .or_else(|| {
-                        value
-                            .get("timeout_ms")
-                            .and_then(Value::as_u64)
-                            .map(|ms| ms.div_ceil(1000).max(1))
-                    })
-                    .unwrap_or(default_timeout_secs);
-                let cwd = value
-                    .get("workdir")
-                    .or_else(|| value.get("cwd"))
-                    .and_then(Value::as_str)
-                    .map(PathBuf::from)
-                    .map(|path| {
-                        if path.is_absolute() {
-                            path
-                        } else {
-                            session_dir.join(path)
-                        }
-                    })
-                    .unwrap_or_else(|| session_dir.to_path_buf());
-                return ShellRequest {
-                    command: normalize_shell_command_text(command),
-                    cwd,
-                    timeout_secs,
-                };
-            }
-        }
+                    .map(|ms| ms.div_ceil(1000).max(1))
+            })
+            .unwrap_or(default_timeout_secs);
+        let cwd = value
+            .get("workdir")
+            .or_else(|| value.get("cwd"))
+            .and_then(Value::as_str)
+            .map(PathBuf::from)
+            .map(|path| {
+                if path.is_absolute() {
+                    path
+                } else {
+                    session_dir.join(path)
+                }
+            })
+            .unwrap_or_else(|| session_dir.to_path_buf());
+        return ShellRequest {
+            command: normalize_shell_command_text(command),
+            cwd,
+            timeout_secs,
+        };
     }
     ShellRequest {
         command: normalize_shell_command_text(command_line),
@@ -227,10 +225,10 @@ fn decode_loose_json_string(raw: &str) -> Option<String> {
             'f' => decoded.push('\u{000c}'),
             'u' => {
                 let digits = chars.by_ref().take(4).collect::<String>();
-                if let Ok(code) = u16::from_str_radix(&digits, 16) {
-                    if let Some(value) = char::from_u32(code as u32) {
-                        decoded.push(value);
-                    }
+                if let Ok(code) = u16::from_str_radix(&digits, 16)
+                    && let Some(value) = char::from_u32(code as u32)
+                {
+                    decoded.push(value);
                 }
             }
             other => {

--- a/crates/tools/tests/business/command_interceptor_e2e.rs
+++ b/crates/tools/tests/business/command_interceptor_e2e.rs
@@ -31,8 +31,22 @@ fn workspace(name: &str) -> PathBuf {
 
 fn run_bash(root: &Path, command: &str) -> serde_json::Value {
     let _guard = ENV_LOCK.lock().expect("env lock");
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash");
-    std::env::remove_var("TURA_COMMAND_INTERCEPTOR_DISABLED");
+    // SAFETY: this helper holds ENV_LOCK for the duration of the environment access.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash")
+    };
+    // SAFETY: this helper holds ENV_LOCK for the duration of the environment access.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_COMMAND_INTERCEPTOR_DISABLED")
+    };
     command_run::execute(
         &json!({
             "commands": [
@@ -54,8 +68,22 @@ fn zsh_available() -> bool {
 
 fn run_zsh(root: &Path, command: &str) -> serde_json::Value {
     let _guard = ENV_LOCK.lock().expect("env lock");
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "zsh");
-    std::env::remove_var("TURA_COMMAND_INTERCEPTOR_DISABLED");
+    // SAFETY: this helper holds ENV_LOCK for the duration of the environment access.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "zsh")
+    };
+    // SAFETY: this helper holds ENV_LOCK for the duration of the environment access.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_COMMAND_INTERCEPTOR_DISABLED")
+    };
     command_run::execute(
         &json!({
             "commands": [
@@ -279,8 +307,22 @@ fn non_destructive_rm_of_single_file_still_runs() {
 #[test]
 fn interceptor_opt_out_allows_safe_command_to_execute() {
     let _guard = ENV_LOCK.lock().expect("env lock");
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash");
-    std::env::set_var("TURA_COMMAND_INTERCEPTOR_DISABLED", "1");
+    // SAFETY: this test holds ENV_LOCK for the duration of the environment access.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash")
+    };
+    // SAFETY: this test holds ENV_LOCK for the duration of the environment access.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_INTERCEPTOR_DISABLED", "1")
+    };
 
     let root = workspace("opt-out");
     let marker = root.join("optout-safe.txt");
@@ -294,7 +336,14 @@ fn interceptor_opt_out_allows_safe_command_to_execute() {
         &root,
     );
 
-    std::env::remove_var("TURA_COMMAND_INTERCEPTOR_DISABLED");
+    // SAFETY: this test holds ENV_LOCK for the duration of the environment access.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_COMMAND_INTERCEPTOR_DISABLED")
+    };
 
     assert_eq!(
         output["results"][0]["success"], true,

--- a/crates/tools/tests/business/command_run_current/apply_patch_streaming_locks.rs
+++ b/crates/tools/tests/business/command_run_current/apply_patch_streaming_locks.rs
@@ -80,7 +80,14 @@ fn pass_apply_patch_add_delete_and_move_are_tracked_in_output() {
 fn pass_apply_patch_allows_path_outside_workspace_without_cli_sandbox() {
     let _guard = env_lock_blocking();
     let previous_sandbox = std::env::var_os("TURA_COMMAND_RUN_SANDBOX");
-    std::env::remove_var("TURA_COMMAND_RUN_SANDBOX");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_COMMAND_RUN_SANDBOX")
+    };
     let root = temp_workspace("patch-outside-default");
     let outside = root
         .parent()
@@ -113,7 +120,14 @@ fn pass_apply_patch_allows_path_outside_workspace_without_cli_sandbox() {
 fn fail_apply_patch_rejects_path_outside_workspace_when_cli_sandboxed() {
     let _guard = env_lock_blocking();
     let previous_sandbox = std::env::var_os("TURA_COMMAND_RUN_SANDBOX");
-    std::env::set_var("TURA_COMMAND_RUN_SANDBOX", "1");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SANDBOX", "1")
+    };
     let root = temp_workspace("patch-outside");
     let outside = root
         .parent()
@@ -145,7 +159,14 @@ fn fail_apply_patch_rejects_path_outside_workspace_when_cli_sandboxed() {
 #[test]
 fn pass_shell_embedded_apply_patch_is_intercepted_before_shell_execution() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("embedded-patch");
     fs::write(root.join("app.txt"), "old\n").expect("fixture should be written");
     let command_line = "@'\n*** Begin Patch\n*** Update File: app.txt\n@@\n-old\n+new\n*** End Patch\n'@ | apply_patch";
@@ -195,7 +216,14 @@ fn pass_command_line_wrapped_apply_patch_routes_to_apply_patch() {
 #[test]
 fn pass_aliases_cmd_and_command_line_are_accepted() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("aliases");
     let output = command_run::execute(
         &json!({
@@ -213,7 +241,14 @@ fn pass_aliases_cmd_and_command_line_are_accepted() {
 #[test]
 fn pass_single_shell_object_without_commands_is_wrapped() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("single-shell-object");
     let output = command_run::execute(
         &json!({
@@ -465,7 +500,14 @@ fn pass_streaming_executor_repairs_scrambled_steps_without_accidental_grouping()
 #[test]
 fn pass_mutating_commands_are_barriers_between_read_batches() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("barrier");
     fs::write(root.join("state.txt"), "before\n").expect("state fixture should be written");
 
@@ -500,7 +542,14 @@ fn pass_mutating_commands_are_barriers_between_read_batches() {
 #[test]
 fn pass_same_step_commands_keep_dependency_group() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("shared-read-step");
     fs::write(root.join("state.txt"), "ready\n").expect("state fixture should be written");
     let command_a = if cfg!(windows) {
@@ -533,7 +582,14 @@ fn pass_same_step_commands_keep_dependency_group() {
 #[tokio::test]
 async fn pass_later_steps_wait_while_step_two_is_running() {
     let _guard = env_lock().await;
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("step-two-running-barrier");
     let gate = root.join("release-step-two.flag");
     let step_two = if cfg!(windows) {
@@ -638,7 +694,14 @@ async fn pass_later_steps_wait_while_step_two_is_running() {
 #[test]
 fn pass_scrambled_steps_are_repaired_without_accidental_parallel_grouping() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("scrambled-steps");
 
     let output = command_run::execute(
@@ -787,7 +850,14 @@ fn pass_file_lock_releases_after_panic_and_allows_retry() {
 #[test]
 fn pass_same_step_mutating_shell_commands_are_serialized_by_workspace_lock() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("same-step-mutating-serialized");
     let command = |label: &str| {
         if cfg!(windows) {
@@ -837,7 +907,14 @@ fn pass_same_step_mutating_shell_commands_are_serialized_by_workspace_lock() {
 #[tokio::test]
 async fn pass_failed_mutating_command_releases_workspace_lock_for_retry() {
     let _guard = env_lock().await;
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("failed-mutating-retry");
     let failing_command = if cfg!(windows) {
         "Set-Content -Path failed-before-retry.txt -Value before; exit 9"

--- a/crates/tools/tests/business/command_run_current/command_shapes.rs
+++ b/crates/tools/tests/business/command_run_current/command_shapes.rs
@@ -3,7 +3,14 @@ use super::helpers::*;
 #[test]
 fn pass_shell_command_output_matches_current_structured_code_mode() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("shell-output");
     let output = command_run::execute(
         &json!({
@@ -26,7 +33,14 @@ fn pass_shell_command_output_matches_current_structured_code_mode() {
 #[test]
 fn pass_model_backfill_matches_current_shape_except_command_type_key() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("model-backfill");
     let output = command_run::execute(
         &json!({
@@ -64,7 +78,14 @@ fn pass_model_backfill_matches_current_shape_except_command_type_key() {
 #[test]
 fn pass_command_only_shell_text_is_mapped_to_active_shell_command() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("command-only-shell");
     let output = command_run::execute(
         &json!({
@@ -85,7 +106,14 @@ fn pass_command_only_shell_text_is_mapped_to_active_shell_command() {
 #[test]
 fn pass_top_level_workdir_is_accepted_for_current_style_shell_items() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("top-level-workdir");
     let output = command_run::execute(
         &json!({
@@ -104,8 +132,22 @@ fn pass_top_level_workdir_is_accepted_for_current_style_shell_items() {
 fn fail_cli_sandbox_rejects_shell_workdir_outside_workspace() {
     let _guard = env_lock_blocking();
     let previous_sandbox = std::env::var_os("TURA_COMMAND_RUN_SANDBOX");
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
-    std::env::set_var("TURA_COMMAND_RUN_SANDBOX", "1");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SANDBOX", "1")
+    };
     let root = temp_workspace("sandbox-shell-workdir");
     let outside = root
         .parent()
@@ -136,7 +178,14 @@ fn fail_cli_sandbox_rejects_shell_workdir_outside_workspace() {
 #[test]
 fn pass_unknown_command_with_shell_payload_is_mapped_to_active_shell_command() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("unknown-command-payload");
     let output = command_run::execute(
         &json!({
@@ -161,7 +210,14 @@ fn pass_unknown_command_with_shell_payload_is_mapped_to_active_shell_command() {
 #[test]
 fn pass_unknown_command_without_payload_runs_command_text_as_shell() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("unknown-command-no-payload");
     let output = command_run::execute(
         &json!({
@@ -186,7 +242,14 @@ fn pass_unknown_command_without_payload_runs_command_text_as_shell() {
 #[test]
 fn pass_command_line_without_command_defaults_to_active_shell_command() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("command-line-only");
     let output = command_run::execute(
         &json!({
@@ -210,7 +273,14 @@ fn pass_command_line_without_command_defaults_to_active_shell_command() {
 #[test]
 fn pass_command_line_without_command_type_accepts_workdir_and_timeout() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("default-shell-workdir");
     let subdir = root.join("subdir");
     fs::create_dir_all(&subdir).expect("temp subdir");
@@ -242,7 +312,14 @@ fn pass_command_line_without_command_type_accepts_workdir_and_timeout() {
 #[test]
 fn pass_legacy_steps_shape_is_accepted() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("legacy-steps");
     let output = command_run::execute(
         &json!({
@@ -267,7 +344,14 @@ fn pass_legacy_steps_shape_is_accepted() {
 #[test]
 fn pass_command_run_arguments_accept_requests_wrapper_and_json_fence() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("json-fence");
     let output = command_run::execute(
         &Value::String(

--- a/crates/tools/tests/business/command_run_current/read_media.rs
+++ b/crates/tools/tests/business/command_run_current/read_media.rs
@@ -3,7 +3,14 @@ use super::helpers::*;
 #[test]
 fn pass_current_style_command_run_output_shape() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("shape");
 
     let output = command_run::execute(
@@ -29,7 +36,14 @@ fn pass_current_style_command_run_output_shape() {
 #[tokio::test]
 async fn pass_internal_command_rebuilds_tool_call_and_dispatches_router_handler() {
     let _guard = env_lock().await;
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("router");
     let router = ToolRouter::new();
     let call = ToolCall {

--- a/crates/tools/tests/business/command_run_current/task_status_planning.rs
+++ b/crates/tools/tests/business/command_run_current/task_status_planning.rs
@@ -3,7 +3,14 @@ use super::helpers::*;
 #[test]
 fn pass_missing_steps_default_to_original_order() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("steps");
     let output = command_run::execute(
         &json!({
@@ -22,7 +29,14 @@ fn pass_missing_steps_default_to_original_order() {
 #[test]
 fn pass_top_level_task_status_argument_is_not_model_visible() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("top-level-task-status");
 
     let output = command_run::execute(
@@ -41,7 +55,14 @@ fn pass_top_level_task_status_argument_is_not_model_visible() {
 #[test]
 fn pass_planning_command_routes_through_command_run() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_FORCE_EXECUTE_TOOLS_PLANNING", "1");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_FORCE_EXECUTE_TOOLS_PLANNING", "1")
+    };
     let root = temp_workspace("planning");
 
     let output = command_run::execute(
@@ -56,7 +77,14 @@ fn pass_planning_command_routes_through_command_run() {
         &root,
     );
 
-    std::env::remove_var("TURA_FORCE_EXECUTE_TOOLS_PLANNING");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_FORCE_EXECUTE_TOOLS_PLANNING")
+    };
 
     assert_eq!(output["results"][0]["success"], true);
     assert_eq!(output["results"][0]["command_type"], "planning");
@@ -170,8 +198,22 @@ fn fail_task_status_rejects_status_outside_doing_question_or_done() {
 #[test]
 fn fail_planning_command_is_unavailable_by_default() {
     let _guard = env_lock_blocking();
-    std::env::remove_var("TURA_FORCE_PLANNING");
-    std::env::remove_var("TURA_FORCE_EXECUTE_TOOLS_PLANNING");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_FORCE_PLANNING")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_FORCE_EXECUTE_TOOLS_PLANNING")
+    };
     let root = temp_workspace("planning-disabled");
 
     let output = command_run::execute(
@@ -222,7 +264,14 @@ async fn fail_command_run_rejects_commands_outside_agent_capabilities() {
 #[test]
 fn pass_task_status_compact_context_routes_and_outputs_summary() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("compact-context");
     let output = command_run::execute(
         &json!({
@@ -253,7 +302,14 @@ fn pass_task_status_compact_context_routes_and_outputs_summary() {
 #[test]
 fn fail_task_status_compact_context_must_be_final_highest_step() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("compact-context-position");
     let output = command_run::execute(
         &json!({

--- a/crates/tools/tests/business/command_run_current/web_discover.rs
+++ b/crates/tools/tests/business/command_run_current/web_discover.rs
@@ -38,7 +38,14 @@ fn pass_web_discover_image_download_writes_image() {
         }
     });
 
-    std::env::set_var("TURA_IMAGE_SEARCH_ENDPOINT", endpoint);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_IMAGE_SEARCH_ENDPOINT", endpoint)
+    };
     let output = command_run::execute(
         &json!({
             "commands": [
@@ -51,7 +58,14 @@ fn pass_web_discover_image_download_writes_image() {
         }),
         &root,
     );
-    std::env::remove_var("TURA_IMAGE_SEARCH_ENDPOINT");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_IMAGE_SEARCH_ENDPOINT")
+    };
     server.join().expect("server joins");
 
     assert_eq!(output["results"][0]["command_type"], "web_discover");
@@ -124,8 +138,22 @@ fn pass_web_discover_image_uses_brave_endpoint_when_key_is_set() {
         }
     });
 
-    std::env::set_var("TURA_BRAVE_SEARCH_API_KEY", "test-key");
-    std::env::set_var("TURA_BRAVE_IMAGE_SEARCH_ENDPOINT", endpoint);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_BRAVE_SEARCH_API_KEY", "test-key")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_BRAVE_IMAGE_SEARCH_ENDPOINT", endpoint)
+    };
     let output = command_run::execute(
         &json!({
             "commands": [
@@ -138,8 +166,22 @@ fn pass_web_discover_image_uses_brave_endpoint_when_key_is_set() {
         }),
         &root,
     );
-    std::env::remove_var("TURA_BRAVE_SEARCH_API_KEY");
-    std::env::remove_var("TURA_BRAVE_IMAGE_SEARCH_ENDPOINT");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_BRAVE_SEARCH_API_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_BRAVE_IMAGE_SEARCH_ENDPOINT")
+    };
     server.join().expect("server joins");
 
     assert_eq!(output["results"][0]["command_type"], "web_discover");
@@ -215,10 +257,38 @@ fn pass_web_discover_image_reads_brave_key_from_tura_config() {
         }
     });
 
-    std::env::remove_var("TURA_BRAVE_SEARCH_API_KEY");
-    std::env::remove_var("BRAVE_API_KEY");
-    std::env::remove_var("TURA_BRAVE_IMAGE_SEARCH_ENDPOINT");
-    std::env::set_var("TURA_ENV_PATH", &env_path);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_BRAVE_SEARCH_API_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("BRAVE_API_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_BRAVE_IMAGE_SEARCH_ENDPOINT")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_ENV_PATH", &env_path)
+    };
     let output = command_run::execute(
         &json!({
             "commands": [
@@ -231,7 +301,14 @@ fn pass_web_discover_image_reads_brave_key_from_tura_config() {
         }),
         &root,
     );
-    std::env::remove_var("TURA_ENV_PATH");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_ENV_PATH")
+    };
     server.join().expect("server joins");
 
     assert_eq!(output["results"][0]["command_type"], "web_discover");
@@ -290,13 +367,62 @@ fn pass_web_discover_image_uses_duckduckgo_fallback_without_brave() {
         }
     });
 
-    std::env::remove_var("TURA_IMAGE_SEARCH_ENDPOINT");
-    std::env::remove_var("TURA_BRAVE_SEARCH_API_KEY");
-    std::env::remove_var("BRAVE_API_KEY");
-    std::env::set_var("TURA_BRAVE_SEARCH_DISABLED", "1");
-    std::env::set_var("TURA_EXA_SEARCH_DISABLED", "1");
-    std::env::set_var("TURA_DUCKDUCKGO_IMAGE_PAGE_ENDPOINT", page_endpoint);
-    std::env::set_var("TURA_DUCKDUCKGO_IMAGE_SEARCH_ENDPOINT", search_endpoint);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_IMAGE_SEARCH_ENDPOINT")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_BRAVE_SEARCH_API_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("BRAVE_API_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_BRAVE_SEARCH_DISABLED", "1")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_EXA_SEARCH_DISABLED", "1")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_DUCKDUCKGO_IMAGE_PAGE_ENDPOINT", page_endpoint)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_DUCKDUCKGO_IMAGE_SEARCH_ENDPOINT", search_endpoint)
+    };
     let output = command_run::execute(
         &json!({
             "commands": [
@@ -309,10 +435,38 @@ fn pass_web_discover_image_uses_duckduckgo_fallback_without_brave() {
         }),
         &root,
     );
-    std::env::remove_var("TURA_BRAVE_SEARCH_DISABLED");
-    std::env::remove_var("TURA_EXA_SEARCH_DISABLED");
-    std::env::remove_var("TURA_DUCKDUCKGO_IMAGE_PAGE_ENDPOINT");
-    std::env::remove_var("TURA_DUCKDUCKGO_IMAGE_SEARCH_ENDPOINT");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_BRAVE_SEARCH_DISABLED")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_EXA_SEARCH_DISABLED")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_DUCKDUCKGO_IMAGE_PAGE_ENDPOINT")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_DUCKDUCKGO_IMAGE_SEARCH_ENDPOINT")
+    };
     server.join().expect("server joins");
 
     assert_eq!(output["results"][0]["command_type"], "web_discover");
@@ -364,13 +518,62 @@ fn pass_web_discover_image_min_size_filters_small_downloads() {
         }
     });
 
-    std::env::remove_var("TURA_IMAGE_SEARCH_ENDPOINT");
-    std::env::remove_var("TURA_BRAVE_SEARCH_API_KEY");
-    std::env::remove_var("BRAVE_API_KEY");
-    std::env::set_var("TURA_BRAVE_SEARCH_DISABLED", "1");
-    std::env::set_var("TURA_EXA_SEARCH_DISABLED", "1");
-    std::env::set_var("TURA_DUCKDUCKGO_IMAGE_PAGE_ENDPOINT", page_endpoint);
-    std::env::set_var("TURA_DUCKDUCKGO_IMAGE_SEARCH_ENDPOINT", search_endpoint);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_IMAGE_SEARCH_ENDPOINT")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_BRAVE_SEARCH_API_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("BRAVE_API_KEY")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_BRAVE_SEARCH_DISABLED", "1")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_EXA_SEARCH_DISABLED", "1")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_DUCKDUCKGO_IMAGE_PAGE_ENDPOINT", page_endpoint)
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_DUCKDUCKGO_IMAGE_SEARCH_ENDPOINT", search_endpoint)
+    };
     let output = command_run::execute(
         &json!({
             "commands": [
@@ -383,10 +586,38 @@ fn pass_web_discover_image_min_size_filters_small_downloads() {
         }),
         &root,
     );
-    std::env::remove_var("TURA_BRAVE_SEARCH_DISABLED");
-    std::env::remove_var("TURA_EXA_SEARCH_DISABLED");
-    std::env::remove_var("TURA_DUCKDUCKGO_IMAGE_PAGE_ENDPOINT");
-    std::env::remove_var("TURA_DUCKDUCKGO_IMAGE_SEARCH_ENDPOINT");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_BRAVE_SEARCH_DISABLED")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_EXA_SEARCH_DISABLED")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_DUCKDUCKGO_IMAGE_PAGE_ENDPOINT")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_DUCKDUCKGO_IMAGE_SEARCH_ENDPOINT")
+    };
     server.join().expect("server joins");
 
     assert_eq!(output["results"][0]["command_type"], "web_discover");
@@ -438,7 +669,14 @@ fn pass_web_discover_website_download_writes_markdown() {
         }
     });
 
-    std::env::set_var("TURA_WEB_DISCOVER_ENDPOINT", endpoint);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_DISCOVER_ENDPOINT", endpoint)
+    };
     let output = command_run::execute(
         &json!({
             "commands": [
@@ -451,7 +689,14 @@ fn pass_web_discover_website_download_writes_markdown() {
         }),
         &root,
     );
-    std::env::remove_var("TURA_WEB_DISCOVER_ENDPOINT");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_WEB_DISCOVER_ENDPOINT")
+    };
     server.join().expect("server joins");
 
     assert_eq!(output["results"][0]["command_type"], "web_discover");
@@ -484,7 +729,14 @@ fn pass_web_discover_direct_website_returns_structured_record_and_markdown() {
         write_http_response(&mut stream, "text/html", &body);
     });
 
-    std::env::set_var("TURA_WEB_READER_DISABLED", "1");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_WEB_READER_DISABLED", "1")
+    };
     let output = command_run::execute(
         &json!({
             "commands": [
@@ -497,7 +749,14 @@ fn pass_web_discover_direct_website_returns_structured_record_and_markdown() {
         }),
         &root,
     );
-    std::env::remove_var("TURA_WEB_READER_DISABLED");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_WEB_READER_DISABLED")
+    };
     server.join().expect("server joins");
 
     assert_eq!(output["results"][0]["success"], true);

--- a/crates/tools/tests/business/helpers/command_run_current.rs
+++ b/crates/tools/tests/business/helpers/command_run_current.rs
@@ -28,9 +28,23 @@ pub(crate) fn env_lock_blocking() -> tokio::sync::MutexGuard<'static, ()> {
 
 pub(crate) fn restore_env_var(name: &str, value: Option<OsString>) {
     if let Some(value) = value {
-        std::env::set_var(name, value);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var(name, value)
+        };
     } else {
-        std::env::remove_var(name);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var(name)
+        };
     }
 }
 

--- a/crates/tools/tests/live/web_discover_live_provider_check.rs
+++ b/crates/tools/tests/live/web_discover_live_provider_check.rs
@@ -58,11 +58,25 @@ fn configure_provider(provider: &str) {
 }
 
 fn set_env(key: &str, value: &str) {
-    std::env::set_var(key, value);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var(key, value)
+    };
 }
 
 fn remove_env(key: &str) {
-    std::env::remove_var(key);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var(key)
+    };
 }
 
 fn run_case(session_dir: &Path, provider: &str, name: &str, command_line: String) -> Value {
@@ -224,8 +238,7 @@ fn live_direct_image_and_youtube_url_download() {
     let markdown = std::fs::read_to_string(session_dir.join(page_path)).expect("read page md");
     assert!(markdown.contains("profile_member"), "{markdown}");
 
-    let profile_image_url =
-        "https://officialsite.cds-jp.online/prod/profile_member/105/158/2c38bd5497b94e38aba150b784a7de87.webp";
+    let profile_image_url = "https://officialsite.cds-jp.online/prod/profile_member/105/158/2c38bd5497b94e38aba150b784a7de87.webp";
     let image_command = format!(
         "web_discover image \"{profile_image_url}\" --download-dir media/newjeans --min-size=10000"
     );

--- a/crates/tools/tests/os_testing/command_run_shell_process_hooks.rs
+++ b/crates/tools/tests/os_testing/command_run_shell_process_hooks.rs
@@ -26,7 +26,14 @@ fn command_result_text(result: &Value) -> String {
 #[test]
 fn pass_timeout_returns_quick_failure() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("timeout");
     let command = if cfg!(windows) {
         "Start-Sleep -Seconds 10"
@@ -58,7 +65,14 @@ fn pass_timeout_returns_quick_failure() {
 #[test]
 fn fail_timeout_kills_descendant_process_tree_quickly() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash")
+    };
     let root = temp_workspace("descendant-timeout");
     let started = Instant::now();
     let output = command_run::execute(
@@ -85,7 +99,14 @@ fn fail_timeout_kills_descendant_process_tree_quickly() {
 #[tokio::test]
 async fn pass_async_command_run_entry_does_not_start_nested_runtime() {
     let _guard = env_lock().await;
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("async-entry");
     let command = if cfg!(windows) {
         "Write-Output async-ok"
@@ -109,7 +130,14 @@ async fn pass_async_command_run_entry_does_not_start_nested_runtime() {
 #[test]
 fn pass_bash_surface_runs_posix_script_without_exposing_shell_command() {
     let _guard = env_lock_blocking();
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash")
+    };
     let root = temp_workspace("bash-script");
     let output = command_run::execute(
         &json!({
@@ -141,7 +169,14 @@ fn pass_zsh_surface_runs_zsh_script_without_exposing_shell_command() {
         eprintln!("zsh unavailable; skipping zsh execution fixture");
         return;
     }
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "zsh");
+    // SAFETY: this test holds the process-wide environment lock above.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "zsh")
+    };
     let root = temp_workspace("zsh-script");
     let output = command_run::execute(
         &json!({
@@ -169,15 +204,29 @@ fn fail_zsh_surface_reports_missing_configured_binary() {
     let _guard = env_lock_blocking();
     let previous_shell = std::env::var_os("TURA_COMMAND_RUN_SHELL");
     let previous_zsh_path = std::env::var_os("TURA_ZSH_PATH");
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "zsh");
-    std::env::set_var(
-        "TURA_ZSH_PATH",
-        if cfg!(windows) {
-            r"C:\definitely\missing\tura-zsh.exe"
-        } else {
-            "/definitely/missing/tura-zsh"
-        },
-    );
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "zsh")
+    };
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var(
+            "TURA_ZSH_PATH",
+            if cfg!(windows) {
+                r"C:\definitely\missing\tura-zsh.exe"
+            } else {
+                "/definitely/missing/tura-zsh"
+            },
+        )
+    };
     let root = temp_workspace("zsh-missing");
     let output = command_run::execute(
         &json!({
@@ -202,19 +251,40 @@ fn fail_zsh_surface_reports_missing_configured_binary() {
 fn pass_shell_surface_isolation_canonicalizes_to_one_active_shell() {
     let _guard = env_lock_blocking();
 
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash")
+    };
     assert_eq!(commands::canonical_command("shell_command"), "bash");
     assert_eq!(commands::canonical_command("shll"), "bash");
     assert_eq!(commands::canonical_command("bash"), "bash");
     assert_eq!(commands::canonical_command("zsh"), "bash");
 
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "zsh");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "zsh")
+    };
     assert_eq!(commands::canonical_command("shell_command"), "zsh");
     assert_eq!(commands::canonical_command("shll"), "zsh");
     assert_eq!(commands::canonical_command("bash"), "zsh");
     assert_eq!(commands::canonical_command("zsh"), "zsh");
 
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shll");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shll")
+    };
     assert_eq!(commands::canonical_command("bash"), "shell_command");
     assert_eq!(commands::canonical_command("zsh"), "shell_command");
     assert_eq!(
@@ -226,7 +296,14 @@ fn pass_shell_surface_isolation_canonicalizes_to_one_active_shell() {
 #[tokio::test]
 async fn fail_pre_tool_hook_blocks_tool_before_runtime() {
     let _guard = env_lock().await;
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("pre-hook");
     let ctx = ToolContext::new(root);
     ctx.set_pre_hook(|call| {
@@ -259,7 +336,14 @@ async fn fail_pre_tool_hook_blocks_tool_before_runtime() {
 #[tokio::test]
 async fn pass_post_tool_hook_can_replace_model_visible_response() {
     let _guard = env_lock().await;
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("post-hook");
     let ctx = ToolContext::new(root);
     ctx.set_post_hook(|_call, output: &mut FunctionToolOutput| {
@@ -298,7 +382,14 @@ async fn pass_post_tool_hook_can_replace_model_visible_response() {
 #[tokio::test]
 async fn pass_shell_runtime_records_stdout_stderr_delta_events() {
     let _guard = env_lock().await;
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("stream-delta");
     let command = if cfg!(windows) {
         "Write-Output out-delta; [Console]::Error.WriteLine('err-delta')"
@@ -343,7 +434,14 @@ async fn pass_shell_runtime_records_stdout_stderr_delta_events() {
 #[tokio::test]
 async fn fail_turn_cancellation_aborts_running_shell_command() {
     let _guard = env_lock().await;
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let root = temp_workspace("cancel");
     let command = if cfg!(windows) {
         "Start-Sleep -Seconds 10"
@@ -381,7 +479,14 @@ async fn fail_turn_cancellation_aborts_running_shell_command() {
 #[tokio::test]
 async fn pass_concurrent_shell_command_runs_do_not_block_async_runtime_or_cross_workspaces() {
     let _guard = env_lock().await;
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "shell_command")
+    };
     let roots = (0..4)
         .map(|index| temp_workspace(&format!("concurrent-shell-{index}")))
         .collect::<Vec<_>>();
@@ -451,7 +556,14 @@ async fn pass_concurrent_shell_command_runs_do_not_block_async_runtime_or_cross_
 #[tokio::test]
 async fn fail_timeout_aborts_reader_drain_for_pipe_holding_descendants() {
     let _guard = env_lock().await;
-    std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_COMMAND_RUN_SHELL", "bash")
+    };
     let root = temp_workspace("reader-drain");
     let router = ToolRouter::new();
     let call = ToolCall {

--- a/tests/equivalence/runtime_session/runner/Cargo.toml
+++ b/tests/equivalence/runtime_session/runner/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 
 [package]
 name = "runtime-session-equivalence"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/tests/equivalence/runtime_session/runner/src/bin/inventory.rs
+++ b/tests/equivalence/runtime_session/runner/src/bin/inventory.rs
@@ -147,9 +147,7 @@ fn collect_test_items(items: &[syn::Item], relative: &str, rows: &mut Vec<TestRo
             && visitor.string_literals.iter().any(|text| {
                 let literal = text
                     .trim_matches(|character: char| character == '"' || character.is_whitespace());
-                literal.ends_with(".rs")
-                    || literal.ends_with(".ts")
-                    || literal.ends_with(".tsx")
+                literal.ends_with(".rs") || literal.ends_with(".ts") || literal.ends_with(".tsx")
             });
         let replacement = source_text_dependency.then(|| "required_before_deletion".to_string());
         rows.push(TestRow {

--- a/tests/equivalence/runtime_session/runner/src/main.rs
+++ b/tests/equivalence/runtime_session/runner/src/main.rs
@@ -39,9 +39,30 @@ impl EquivalenceSessionDb {
         let home = root.path().join("home");
         std::fs::create_dir_all(&home)?;
         let store = SessionLogStore::open(root.path())?;
-        std::env::set_var("TURA_HOME", &home);
-        std::env::set_var("SESSION_LOG_DB_ROOT", root.path());
-        std::env::remove_var("TURA_DB_ROOT");
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_HOME", &home)
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("SESSION_LOG_DB_ROOT", root.path())
+        };
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::remove_var("TURA_DB_ROOT")
+        };
 
         let handle = std::thread::spawn(move || {
             session_log::ipc::serve_blocking(store)
@@ -95,8 +116,26 @@ impl Drop for EquivalenceSessionDb {
         }
         for (key, value) in self.previous_environment.drain(..).rev() {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }
@@ -293,7 +332,7 @@ fn gateway_busy_input_capture() -> Result<Value, Box<dyn std::error::Error>> {
     let taken = match consumed.event {
         SessionEvent::QueuedUserInputsConsumed { inputs } => inputs,
         event => {
-            return Err(io::Error::other(format!("unexpected consume event: {event:?}")).into())
+            return Err(io::Error::other(format!("unexpected consume event: {event:?}")).into());
         }
     };
     let empty = consumed.projection.pending_user_inputs;

--- a/tests/os_testing/command_run_router_ownership_e2e.rs
+++ b/tests/os_testing/command_run_router_ownership_e2e.rs
@@ -9,7 +9,14 @@ static MOCK_ROUTER_INIT: Mutex<()> = Mutex::new(());
 #[tokio::test]
 async fn command_run_without_router_addr_does_not_execute_in_runtime_process() {
     let previous = std::env::var("TURA_ROUTER_ADDR").ok();
-    std::env::remove_var("TURA_ROUTER_ADDR");
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::remove_var("TURA_ROUTER_ADDR")
+    };
     let workspace = tempfile::tempdir().expect("workspace");
     let marker = workspace.path().join("must-not-exist.txt");
 
@@ -31,7 +38,14 @@ async fn command_run_without_router_addr_does_not_execute_in_runtime_process() {
     .await;
 
     if let Some(value) = previous {
-        std::env::set_var("TURA_ROUTER_ADDR", value);
+        // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+        #[allow(
+            unsafe_code,
+            reason = "Rust 2024 process-environment mutation audited at the caller"
+        )]
+        unsafe {
+            std::env::set_var("TURA_ROUTER_ADDR", value)
+        };
     }
     assert_eq!(output["ok"], false);
     assert!(
@@ -43,7 +57,14 @@ async fn command_run_without_router_addr_does_not_execute_in_runtime_process() {
 #[tokio::test]
 async fn command_run_executes_only_after_runtime_hands_request_to_router() {
     let router_addr = ensure_mock_router();
-    std::env::set_var("TURA_ROUTER_ADDR", router_addr);
+    // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+    #[allow(
+        unsafe_code,
+        reason = "Rust 2024 process-environment mutation audited at the caller"
+    )]
+    unsafe {
+        std::env::set_var("TURA_ROUTER_ADDR", router_addr)
+    };
     let workspace = tempfile::tempdir().expect("workspace");
 
     let output = runtime::router_command_run::execute_command_run_value_or_error(

--- a/tests/os_testing/helpers/process_state_management.rs
+++ b/tests/os_testing/helpers/process_state_management.rs
@@ -714,7 +714,9 @@ pub(crate) fn gateway_stdin_eof_shuts_down_router_session_db_and_runtime(
     if let Err(error) = wait_for_file_missing(&router_addr_path(&home), PROCESS_EXIT_TIMEOUT) {
         let lifecycle = router_lifecycle_status(&home)
             .unwrap_or_else(|status_error| json!({ "status_error": status_error.to_string() }));
-        bail!("gateway EOF must explicitly shut down router/session_db/runtime-owned work: {error}; lifecycle={lifecycle}");
+        bail!(
+            "gateway EOF must explicitly shut down router/session_db/runtime-owned work: {error}; lifecycle={lifecycle}"
+        );
     }
     wait_for_file_missing(&service_addr_path(&home), PROCESS_EXIT_TIMEOUT)?;
     wait_for_process_dead(router_pid, PROCESS_EXIT_TIMEOUT).with_context(|| {
@@ -1359,7 +1361,7 @@ fn wait_for_gateway_session(port: u16, session_id: &str, timeout: Duration) -> R
                         .any(|session| session["id"].as_str() == Some(session_id))
                 }) =>
             {
-                return Ok(())
+                return Ok(());
             }
             Ok(sessions) => {
                 last_error = Some(anyhow!(

--- a/tests/os_testing/helpers/session_db_restart_queue_resilience.rs
+++ b/tests/os_testing/helpers/session_db_restart_queue_resilience.rs
@@ -755,8 +755,26 @@ impl EnvGuard {
             .collect::<Vec<_>>();
         for (key, value) in values {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
         Self { previous }
@@ -767,8 +785,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..).rev() {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/tests/os_testing/session_db_workspace_flow_e2e.rs
+++ b/tests/os_testing/session_db_workspace_flow_e2e.rs
@@ -793,8 +793,26 @@ impl EnvGuard {
             .collect::<Vec<_>>();
         for (key, value) in values {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
         Self { previous }
@@ -805,8 +823,26 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..).rev() {
             match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                Some(value) => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::set_var(key, value)
+                    }
+                }
+                // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
+                None => {
+                    #[allow(
+                        unsafe_code,
+                        reason = "Rust 2024 process-environment mutation audited at the caller"
+                    )]
+                    unsafe {
+                        std::env::remove_var(key)
+                    }
+                }
             }
         }
     }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,11 +1,11 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = ["."]
 
 [package]
 name = "tura-xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/xtask/rustfmt.toml
+++ b/xtask/rustfmt.toml
@@ -1,3 +1,4 @@
-edition = "2021"
+edition = "2024"
+style_edition = "2021"
 max_width = 100
 newline_style = "Auto"


### PR DESCRIPTION
## Pull request type

Choose one primary type.

- [x] Bug fix
- [ ] Feature or behavior change
- [ ] Performance or efficiency claim
- [ ] Provider compatibility
- [ ] Documentation only
- [ ] Maintenance or other

## Related issue

Fixes #25

## Outcome

Long TUI final responses remain fully recoverable after a nearby command completes during streaming. The change freezes the terminal-owned cache/live boundary while a live tail exists, then promotes the complete tail to cache after streaming ends.

## Scope and compatibility

- Changed contracts, state, storage, protocol, CLI, GUI, TUI, or installation behavior: TUI rendering/cache handoff only; no public protocol or storage contract changes.
- Compatibility or migration risk: Low. Existing append-only terminal scrollback behavior is preserved.
- Explicitly out of scope: Gateway/runtime lease handling and non-TUI surfaces.

## Verification

```text
npm --prefix apps/tui run check -> passed
npm --prefix apps/tui run test:unit -> 292 passed, 0 failed
npm --prefix apps/tui run test:business:stream -> passed; all 36 final-response markers present exactly once in xterm buffer
npm --prefix apps/tui run test:e2e -> passed
```

## Type-specific evidence

- Reproduction: a command starts, a 36-line final response streams past the viewport into xterm scrollback, the command completes, then the final response hydrates and the session becomes idle. Before the fix, only lines 19–36 remained recoverable.
- Root cause: completing the command moved it from the live group into the stable cache while the long response still owned terminal scrollback. That shifted the cache/live boundary in front of terminal-owned rows even though drawing is append-only, causing row misalignment and loss of the response prefix.
- Smallest owning regression layer: transcript-cache unit test plus the existing Playwright/xterm business stream flow.

## Safety and responsibility

- [x] No credentials, private session data, unsafe provider logs, or generated local state are included.
- [x] Public evidence was sanitized according to the contribution guide.
- [ ] A human is the primary submitter and accepts responsibility for correctness, licensing, provenance, verification, and the statements in this pull request.
- [ ] I have the right to submit all included code, data, prompts, fixtures, and generated material under the repository license.

Meaningful tool or AI assistance: Tura/Codex was used to reproduce the xterm scrollback failure, implement the minimal cache-boundary fix, and run the listed validation.