### PR TITLE
Add MiniMax provider catalog metadata

### DIFF
--- a/crates/provider/config/provider_config.json
+++ b/crates/provider/config/provider_config.json
@@ -2234,6 +2234,129 @@
         "status": "configured",
         "token_env": null
       },
+      "minimax": {
+        "api_docs": "https://platform.minimax.io/docs/api-reference/api-overview",
+        "api_style": "openapi",
+        "auth_methods": [
+          "api_key"
+        ],
+        "base_url": "https://api.minimax.io/v1",
+        "capabilities": [
+          "llm.chat",
+          "llm.tool_call",
+          "llm.vision"
+        ],
+        "display_name": "MiniMax",
+        "domains": [
+          "llm"
+        ],
+        "env": [
+          "MINIMAX_API_KEY"
+        ],
+        "models": {
+          "embedding_high": [],
+          "embedding_low": [],
+          "fast": [],
+          "thinking": [
+            {
+              "attachment": true,
+              "family": "minimax",
+              "id": "MiniMax-M3",
+              "limit": {
+                "context": 1000000,
+                "input": 1000000,
+                "output": 16384
+              },
+              "modalities": {
+                "input": [
+                  "text",
+                  "image",
+                  "video"
+                ],
+                "output": [
+                  "text"
+                ]
+              },
+              "name": "MiniMax-M3",
+              "options": {
+                "pricing_usd_per_million_tokens": {
+                  "input": 0.6,
+                  "output": 2.4,
+                  "cache_read": 0.12,
+                  "cache_write": null
+                },
+                "regional_endpoints": [
+                  {
+                    "region": "global_en",
+                    "openai_base_url": "https://api.minimax.io/v1",
+                    "anthropic_base_url": "https://api.minimax.io/anthropic"
+                  },
+                  {
+                    "region": "cn_zh",
+                    "openai_base_url": "https://api.minimaxi.com/v1",
+                    "anthropic_base_url": "https://api.minimaxi.com/anthropic"
+                  }
+                ],
+                "thinking": [
+                  "adaptive",
+                  "disabled"
+                ]
+              },
+              "reasoning": true,
+              "temperature": true,
+              "tool_call": true
+            },
+            {
+              "attachment": false,
+              "family": "minimax",
+              "id": "MiniMax-M2.7",
+              "limit": {
+                "context": 204800,
+                "input": 204800,
+                "output": 16384
+              },
+              "modalities": {
+                "input": [
+                  "text"
+                ],
+                "output": [
+                  "text"
+                ]
+              },
+              "name": "MiniMax-M2.7",
+              "options": {
+                "pricing_usd_per_million_tokens": {
+                  "input": 0.3,
+                  "output": 1.2,
+                  "cache_read": 0.06,
+                  "cache_write": 0.375
+                },
+                "regional_endpoints": [
+                  {
+                    "region": "global_en",
+                    "openai_base_url": "https://api.minimax.io/v1",
+                    "anthropic_base_url": "https://api.minimax.io/anthropic"
+                  },
+                  {
+                    "region": "cn_zh",
+                    "openai_base_url": "https://api.minimaxi.com/v1",
+                    "anthropic_base_url": "https://api.minimaxi.com/anthropic"
+                  }
+                ],
+                "thinking": [
+                  "always_on"
+                ]
+              },
+              "reasoning": true,
+              "temperature": true,
+              "tool_call": true
+            }
+          ]
+        },
+        "runtime_provider": "minimax",
+        "status": "configured",
+        "token_env": "MINIMAX_API_KEY"
+      },
       "moonshotai": {
         "api_docs": null,
         "api_style": "openapi",
@@ -4097,6 +4220,10 @@
     "lmstudio": "http://localhost:1234/v1",
     "mailgun": "https://api.mailgun.net/v3",
     "microsoft_graph": "https://graph.microsoft.com/v1.0",
+    "minimax": "https://api.minimax.io/v1",
+    "minimax_anthropic": "https://api.minimax.io/anthropic",
+    "minimax_anthropic_cn": "https://api.minimaxi.com/anthropic",
+    "minimax_cn": "https://api.minimaxi.com/v1",
     "moonshotai": "https://api.moonshot.ai/v1",
     "mistral": "https://api.mistral.ai/v1",
     "notion": "https://api.notion.com/v1",

--- a/crates/provider/src/auth_registry.rs
+++ b/crates/provider/src/auth_registry.rs
@@ -182,6 +182,7 @@ const ANTIGRAVITY_API_MODELS: &[&str] = &[
     "gemini-embedding-2",
 ];
 const DEEPSEEK_MODELS: &[&str] = &["deepseek-v4-pro", "deepseek-v4-flash"];
+const MINIMAX_MODELS: &[&str] = &["MiniMax-M3", "MiniMax-M2.7"];
 const MOONSHOT_MODELS: &[&str] = &["kimi-k2.6"];
 const QWEN_MODELS: &[&str] = &["qwen3.7-max", "qwen3.6-flash", "text-embedding-v4"];
 const XAI_MODELS: &[&str] = &["grok-4.3"];
@@ -484,6 +485,13 @@ pub const PROVIDER_AUTH_REGISTRY: &[ProviderAuthRegistryEntry] = &[
         "https://api.deepseek.com",
     ),
     simple_openai_compatible(
+        "minimax",
+        "MiniMax",
+        "MINIMAX_API_KEY",
+        MINIMAX_MODELS,
+        "https://api.minimax.io/v1",
+    ),
+    simple_openai_compatible(
         "moonshotai",
         "Moonshot AI",
         "MOONSHOTAI_API_KEY",
@@ -716,6 +724,7 @@ mod tests {
             "antigravity-api",
             "openrouter",
             "deepseek",
+            "minimax",
             "moonshotai",
             "qwen",
             "qwen_cn",
@@ -732,6 +741,23 @@ mod tests {
                 "missing registry entry for {provider_id}"
             );
         }
+    }
+
+    #[test]
+    fn minimax_registry_exposes_api_key_models_and_openai_compatible_capabilities() {
+        let entry = provider_auth_registry_entry("minimax").expect("minimax registry entry");
+
+        assert_eq!(entry.runtime_provider_id, "minimax");
+        assert_eq!(entry.default_base_url, "https://api.minimax.io/v1");
+        assert_eq!(entry.token_env, Some("MINIMAX_API_KEY"));
+        assert_eq!(entry.supported_models, MINIMAX_MODELS);
+        assert_eq!(entry.auth_methods.len(), 1);
+        assert_eq!(entry.auth_methods[0].kind, AuthMethodKind::ApiKey);
+        assert_eq!(entry.auth_methods[0].login, "api");
+        assert!(entry.capabilities.supports_api_key);
+        assert!(entry.capabilities.supports_streaming);
+        assert!(entry.capabilities.supports_tool_call_streaming);
+        assert!(entry.capabilities.supports_model_validation);
     }
 
     #[test]

--- a/crates/provider/src/tura_llm_conf.rs
+++ b/crates/provider/src/tura_llm_conf.rs
@@ -88,7 +88,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bundled_config_exposes_four_model_tiers() {
+    async fn bundled_config_exposes_model_tiers_and_minimax_metadata() {
         let _guard = crate::test_support::env_lock_async().await;
         let previous_provider = std::env::var_os("TURA_PROVIDER_CONFIG");
         // SAFETY: the caller ensures no concurrent foreign environment access races with this mutation.
@@ -118,6 +118,93 @@ mod tests {
         assert_eq!(
             settings.provider_base_url("github-copilot").as_deref(),
             Some("https://api.githubcopilot.com")
+        );
+        assert_eq!(
+            settings.provider_base_url("minimax").as_deref(),
+            Some("https://api.minimax.io/v1")
+        );
+        assert_eq!(
+            settings.provider_base_url("minimax_cn").as_deref(),
+            Some("https://api.minimaxi.com/v1")
+        );
+        assert_eq!(
+            settings.provider_base_url("minimax_anthropic").as_deref(),
+            Some("https://api.minimax.io/anthropic")
+        );
+        assert_eq!(
+            settings
+                .provider_base_url("minimax_anthropic_cn")
+                .as_deref(),
+            Some("https://api.minimaxi.com/anthropic")
+        );
+
+        let minimax = settings
+            .model_catalog
+            .providers
+            .get("minimax")
+            .expect("minimax provider catalog");
+        assert_eq!(minimax.runtime_provider, "minimax");
+        assert_eq!(minimax.token_env.as_deref(), Some("MINIMAX_API_KEY"));
+        assert_eq!(minimax.auth_methods, ["api_key"]);
+
+        let minimax_models = minimax.models.get("thinking").expect("minimax models");
+        let minimax_m3 = minimax_models
+            .iter()
+            .find(|model| model.id() == "MiniMax-M3")
+            .and_then(|model| model.detail())
+            .expect("MiniMax-M3 metadata");
+        assert_eq!(minimax_m3.limit.context, 1_000_000);
+        assert_eq!(minimax_m3.limit.input, 1_000_000);
+        assert_eq!(minimax_m3.modalities.input, ["text", "image", "video"]);
+        assert_eq!(
+            minimax_m3.options.get("thinking"),
+            Some(&serde_json::json!(["adaptive", "disabled"]))
+        );
+        assert_eq!(
+            minimax_m3.options.get("pricing_usd_per_million_tokens"),
+            Some(&serde_json::json!({
+                "input": 0.6,
+                "output": 2.4,
+                "cache_read": 0.12,
+                "cache_write": null
+            }))
+        );
+        assert_eq!(
+            minimax_m3.options.get("regional_endpoints"),
+            Some(&serde_json::json!([
+                {
+                    "region": "global_en",
+                    "openai_base_url": "https://api.minimax.io/v1",
+                    "anthropic_base_url": "https://api.minimax.io/anthropic"
+                },
+                {
+                    "region": "cn_zh",
+                    "openai_base_url": "https://api.minimaxi.com/v1",
+                    "anthropic_base_url": "https://api.minimaxi.com/anthropic"
+                }
+            ]))
+        );
+
+        let minimax_m27 = minimax_models
+            .iter()
+            .find(|model| model.id() == "MiniMax-M2.7")
+            .and_then(|model| model.detail())
+            .expect("MiniMax-M2.7 metadata");
+        assert_eq!(minimax_m27.limit.context, 204_800);
+        assert_eq!(minimax_m27.limit.input, 204_800);
+        assert_eq!(minimax_m27.modalities.input, ["text"]);
+        assert_eq!(
+            minimax_m27.options.get("thinking"),
+            Some(&serde_json::json!(["always_on"]))
+        );
+        assert_eq!(
+            minimax_m27.options.get("pricing_usd_per_million_tokens"),
+            Some(&serde_json::json!({
+                "input": 0.3,
+                "output": 1.2,
+                "cache_read": 0.06,
+                "cache_write": 0.375
+            }))
         );
 
         match previous_provider {


### PR DESCRIPTION
Reason: Add MiniMax to Tura's configured LLM provider catalog.

Changes:
- Register MiniMax API-key authentication and current model identifiers.
- Add context, modality, pricing, and thinking metadata for the configured models.
- Include global and China OpenAI-compatible and Anthropic-compatible endpoints.

Checks:
- `cargo test -p provider --lib`
- `cargo test -p gateway provider_auth_methods_are_projected_from_registry --lib`
- `jq -e . crates/provider/config/provider_config.json`
- `git diff --check`
