### PR TITLE
Hotfix/session db transient readonly

### DIFF
--- a/crates/session_log/src/ipc.rs
+++ b/crates/session_log/src/ipc.rs
@@ -268,8 +268,9 @@ impl From<SessionLogResponse> for CommandDispatchOutcome {
 }
 
 /// Bind the service socket, publish its address, and serve commands until the
-/// process exits. One thread per accepted connection; the store clone shares the
-/// underlying connection pool, so concurrent clients run in parallel.
+/// process exits. One thread handles each accepted connection; SQLite operations
+/// are coordinated per database path while clients for different workspaces can
+/// still make progress in parallel.
 pub fn serve_blocking(store: SessionLogStore) -> Result<()> {
     serve_blocking_with_feed_hub(store, SessionFeedHub::default())
 }

--- a/crates/session_log/src/store/connection.rs
+++ b/crates/session_log/src/store/connection.rs
@@ -1,20 +1,28 @@
 use super::SessionLogStore;
 use anyhow::{Context, Result};
 use fs2::FileExt;
-use rusqlite::Connection;
-use std::collections::BTreeSet;
+use rusqlite::{Connection, ffi::ErrorCode};
+use std::collections::{BTreeSet, HashMap};
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 const SQLITE_INIT_LOCK_OPEN_TIMEOUT: Duration = Duration::from_secs(30);
 const SQLITE_INIT_LOCK_OPEN_RETRY_DELAY: Duration = Duration::from_millis(10);
+const SQLITE_OPERATION_RETRY_DELAYS: &[Duration] = &[
+    Duration::from_millis(10),
+    Duration::from_millis(25),
+    Duration::from_millis(50),
+    Duration::from_millis(100),
+    Duration::from_millis(200),
+    Duration::from_millis(400),
+];
 
 impl SessionLogStore {
     pub(super) fn with_index_connection<T>(
         &self,
-        f: impl FnOnce(&mut Connection) -> Result<T>,
+        f: impl FnMut(&mut Connection) -> Result<T>,
     ) -> Result<T> {
         with_connection(&self.index_db_path, init_index_db, f)
     }
@@ -22,7 +30,7 @@ impl SessionLogStore {
     pub(super) fn with_workspace_connection<T>(
         &self,
         path: &Path,
-        f: impl FnOnce(&mut Connection) -> Result<T>,
+        f: impl FnMut(&mut Connection) -> Result<T>,
     ) -> Result<T> {
         with_connection(path, init_workspace_db, f)
     }
@@ -31,12 +39,61 @@ impl SessionLogStore {
 pub(super) fn with_connection<T>(
     path: &Path,
     init: fn(&Connection) -> Result<()>,
-    f: impl FnOnce(&mut Connection) -> Result<T>,
+    mut f: impl FnMut(&mut Connection) -> Result<T>,
 ) -> Result<T> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
+    let operation_lock = sqlite_operation_lock(path);
+    let _operation_guard = operation_lock
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+
+    let mut attempt = 1_usize;
+    loop {
+        match with_connection_once(path, init, &mut f) {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                let sqlite_error = sqlite_error_details(&error);
+                let retry_delay = SQLITE_OPERATION_RETRY_DELAYS.get(attempt - 1).copied();
+                if let (Some((code, extended_code)), Some(retry_delay)) =
+                    (sqlite_error, retry_delay)
+                    && sqlite_error_is_transient((code, extended_code))
+                {
+                    tracing::warn!(
+                        database_path = %path.display(),
+                        attempt,
+                        max_attempts = SQLITE_OPERATION_RETRY_DELAYS.len() + 1,
+                        sqlite_code = ?code,
+                        sqlite_extended_code = extended_code,
+                        retry_delay_ms = retry_delay.as_millis(),
+                        error = %error,
+                        "retrying transient SQLite operation failure"
+                    );
+                    std::thread::sleep(retry_delay);
+                    attempt += 1;
+                    continue;
+                }
+
+                let Some((code, extended_code)) = sqlite_error else {
+                    return Err(error);
+                };
+                let context = format!(
+                    "SQLite operation on {} failed after {attempt} attempt(s); SQLite code {code:?}, extended code {extended_code}: {error}",
+                    path.display()
+                );
+                return Err(error).context(context);
+            }
+        }
+    }
+}
+
+fn with_connection_once<T>(
+    path: &Path,
+    init: fn(&Connection) -> Result<()>,
+    f: &mut impl FnMut(&mut Connection) -> Result<T>,
+) -> Result<T> {
     let mut conn = {
         let _file_guard = sqlite_init_file_lock(path)?;
         let _guard = sqlite_init_lock()
@@ -45,13 +102,66 @@ pub(super) fn with_connection<T>(
         let conn =
             Connection::open(path).with_context(|| format!("failed to open {}", path.display()))?;
         conn.busy_timeout(Duration::from_secs(30))?;
-        conn.pragma_update(None, "journal_mode", "WAL")?;
+        let journal_mode =
+            conn.pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))?;
+        if !journal_mode.eq_ignore_ascii_case("wal") {
+            conn.pragma_update(None, "journal_mode", "WAL")?;
+        }
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
         init(&conn)?;
         conn
     };
     f(&mut conn)
+}
+
+fn sqlite_operation_lock(path: &Path) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>> = OnceLock::new();
+    let locks = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut locks = locks.lock().unwrap_or_else(|error| error.into_inner());
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    let key = sqlite_operation_lock_key(path);
+    if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+        return lock;
+    }
+    let lock = Arc::new(Mutex::new(()));
+    locks.insert(key, Arc::downgrade(&lock));
+    lock
+}
+
+fn sqlite_operation_lock_key(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| {
+        let Some(parent) = path.parent() else {
+            return path.to_path_buf();
+        };
+        parent
+            .canonicalize()
+            .map(|parent| {
+                path.file_name()
+                    .map_or(parent.clone(), |name| parent.join(name))
+            })
+            .unwrap_or_else(|_| path.to_path_buf())
+    })
+}
+
+fn sqlite_error_details(error: &anyhow::Error) -> Option<(ErrorCode, i32)> {
+    error.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<rusqlite::Error>()
+            .and_then(rusqlite::Error::sqlite_error)
+            .map(|error| (error.code, error.extended_code))
+    })
+}
+
+fn sqlite_error_is_transient((code, extended_code): (ErrorCode, i32)) -> bool {
+    match code {
+        ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked => true,
+        ErrorCode::ReadOnly => !matches!(
+            extended_code,
+            rusqlite::ffi::SQLITE_READONLY_DBMOVED | rusqlite::ffi::SQLITE_READONLY_DIRECTORY
+        ),
+        _ => false,
+    }
 }
 
 fn sqlite_init_lock() -> &'static Mutex<()> {
@@ -452,7 +562,8 @@ const WORKSPACE_SCHEMA: &[(&str, &[&str])] = &[
 
 #[cfg(all(test, windows))]
 mod tests {
-    use super::sqlite_init_file_lock;
+    use super::{sqlite_error_is_transient, sqlite_init_file_lock, with_connection};
+    use anyhow::Result;
     use std::fs::OpenOptions;
     use std::os::windows::fs::OpenOptionsExt;
     use std::path::PathBuf;
@@ -480,5 +591,71 @@ mod tests {
         let result = sqlite_init_file_lock(&database_path);
         release.join().expect("release blocker");
         let _guard = result.expect("transient sharing violation should be retried");
+    }
+
+    #[test]
+    fn sqlite_connection_recovers_after_database_is_briefly_read_only() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let database_path = temp.path().join("session_log.sqlite3");
+        with_connection(
+            &database_path,
+            |conn| {
+                conn.execute_batch("CREATE TABLE IF NOT EXISTS events(id INTEGER PRIMARY KEY);")?;
+                Ok(())
+            },
+            |_| Ok(()),
+        )
+        .expect("initialize database");
+
+        let mut permissions = std::fs::metadata(&database_path)
+            .expect("database metadata")
+            .permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&database_path, permissions).expect("make database read-only");
+
+        let release_path = database_path.clone();
+        let release = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(150));
+            let mut permissions = std::fs::metadata(&release_path)
+                .expect("database metadata")
+                .permissions();
+            permissions.set_readonly(false);
+            std::fs::set_permissions(&release_path, permissions).expect("restore database writes");
+        });
+
+        let result = with_connection(
+            &database_path,
+            |_| Ok(()),
+            |conn| -> Result<()> {
+                conn.execute("INSERT INTO events DEFAULT VALUES", [])?;
+                Ok(())
+            },
+        );
+        release.join().expect("release read-only database");
+        result.expect("brief read-only window should be retried");
+    }
+
+    #[test]
+    fn sqlite_retry_classifier_excludes_permanent_readonly_failures() {
+        assert!(sqlite_error_is_transient((
+            rusqlite::ffi::ErrorCode::ReadOnly,
+            rusqlite::ffi::SQLITE_READONLY
+        )));
+        assert!(sqlite_error_is_transient((
+            rusqlite::ffi::ErrorCode::ReadOnly,
+            rusqlite::ffi::SQLITE_READONLY_CANTINIT
+        )));
+        assert!(sqlite_error_is_transient((
+            rusqlite::ffi::ErrorCode::DatabaseBusy,
+            rusqlite::ffi::SQLITE_BUSY
+        )));
+        assert!(!sqlite_error_is_transient((
+            rusqlite::ffi::ErrorCode::ReadOnly,
+            rusqlite::ffi::SQLITE_READONLY_DBMOVED
+        )));
+        assert!(!sqlite_error_is_transient((
+            rusqlite::ffi::ErrorCode::ReadOnly,
+            rusqlite::ffi::SQLITE_READONLY_DIRECTORY
+        )));
     }
 }

--- a/crates/session_log/src/store/connection.rs
+++ b/crates/session_log/src/store/connection.rs
@@ -1,7 +1,7 @@
 use super::SessionLogStore;
 use anyhow::{Context, Result};
 use fs2::FileExt;
-use rusqlite::{Connection, ffi::ErrorCode};
+use rusqlite::{ffi::ErrorCode, Connection};
 use std::collections::{BTreeSet, HashMap};
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};

--- a/crates/session_log/src/store/feed.rs
+++ b/crates/session_log/src/store/feed.rs
@@ -94,15 +94,15 @@ impl SessionLogStore {
                 &event,
             )?;
             let feed_entry = SessionFeedEntry {
-                session_id: request.session_id,
+                session_id: request.session_id.clone(),
                 cursor,
                 runtime_id: None,
-                event_id: request.command_id,
+                event_id: request.command_id.clone(),
                 event,
             };
             tx.commit()?;
             Ok(UpdateSessionTodosOutcome {
-                todos: request.todos,
+                todos: request.todos.clone(),
                 feed_entry: Some(feed_entry),
                 cursor,
             })

--- a/crates/session_log/src/store/runtime_events.rs
+++ b/crates/session_log/src/store/runtime_events.rs
@@ -370,8 +370,8 @@ impl SessionLogStore {
             if events.is_empty() {
                 return Ok(None);
             }
-            let aggregate =
-                RuntimeAggregate::replay(request.runtime_id, events).map_err(anyhow::Error::msg)?;
+            let aggregate = RuntimeAggregate::replay(request.runtime_id.clone(), events)
+                .map_err(anyhow::Error::msg)?;
             Ok(Some(RuntimeReplay {
                 aggregate,
                 revision: row.revision,

--- a/crates/session_log/src/store/session_commands.rs
+++ b/crates/session_log/src/store/session_commands.rs
@@ -81,7 +81,7 @@ impl SessionLogStore {
                     row.next_management_sequence
                 );
             } else {
-                management.apply_persistence_delta(management_delta);
+                management.apply_persistence_delta(management_delta.clone());
                 tx.execute(
                     "INSERT INTO management_deltas(session_id, sequence, delta_json)
                      VALUES (?1, ?2, ?3)",
@@ -122,9 +122,9 @@ impl SessionLogStore {
                     "historical management delta cannot append new context in session {session_id}"
                 );
             }
-            for entry in entries {
+            for entry in &entries {
                 let sequence = entry.context.sequence;
-                let raw_record = entry.context.raw_record;
+                let raw_record = entry.context.raw_record.clone();
                 let projection_json = serde_json::to_string(&entry.projection)?;
                 let inserted_context;
                 if entry.context.sequence < next_sequence {
@@ -172,7 +172,7 @@ impl SessionLogStore {
                     inserted_context = true;
                 }
                 if inserted_context
-                    && let Some(projection) = entry.projection {
+                    && let Some(projection) = entry.projection.clone() {
                         let (inserted, projection) =
                             upsert_delta_projection(&tx, &session_id, projection)?;
                         inserted_messages += inserted;
@@ -480,7 +480,7 @@ impl SessionLogStore {
                         event_id: snapshot_event_id,
                         event: snapshot_event,
                     });
-                    for record in fork_projection.records {
+                    for record in &fork_projection.records {
                         statement.execute(params![
                             &request.session_id,
                             &record.message_id,
@@ -491,7 +491,9 @@ impl SessionLogStore {
                         ])?;
                         let event_id =
                             format!("{}:fork-message:{}", request.session_id, record.message_id);
-                        let event = SessionFeedEvent::MessageUpserted { message: record };
+                        let event = SessionFeedEvent::MessageUpserted {
+                            message: record.clone(),
+                        };
                         let cursor = super::feed::append_session_feed_event_tx(
                             &tx,
                             &request.session_id,
@@ -650,7 +652,7 @@ impl SessionLogStore {
                 .with_context(|| format!("session {} not found", request.session_id))?;
             let mut aggregate = replay_session_events(&tx, &request.session_id)?;
             let previous_task_plan = aggregate.task_plan.clone();
-            let event = aggregate.execute(command)?;
+            let event = aggregate.execute(command.clone())?;
             let projection = aggregate.query(SessionQuery::Lifecycle);
             let task_plan_changed = projection.task_plan != previous_task_plan;
             let publish_task_projection = task_projection_requested || task_plan_changed;
@@ -668,6 +670,7 @@ impl SessionLogStore {
                 chrono::DateTime::<chrono::Utc>::from_timestamp_millis(now_ms)
                     .context("session command timestamp is outside the supported range")?;
             if let Some(name) = auto_name
+                .clone()
                 .filter(|_| task_plan_changed)
                 .filter(|_| management.auto_session_name)
             {

--- a/crates/session_log/tests/performance/store_concurrency_test.rs
+++ b/crates/session_log/tests/performance/store_concurrency_test.rs
@@ -3,9 +3,13 @@ mod typed_session;
 
 use lifecycle::TaskPlan;
 use session_log::SessionLogStore;
-use session_log_contract::ListSessionsRequest;
+use session_log_contract::{
+    ActivateRuntimeLeaseRequest, AppendSessionFeedEventRequest, ListSessionsRequest,
+    ReadSessionFeedRequest, RegisterRuntimeRequest, SessionFeedAppendOutcome, SessionFeedEvent,
+};
 use std::path::Path;
 use std::process::{Child, Command, ExitStatus};
+use std::sync::{Arc, Barrier};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -170,6 +174,151 @@ fn concurrent_typed_writes_keep_pagination_consistent() {
         started.elapsed() < Duration::from_secs(60),
         "concurrent typed write smoke test took {:?}",
         started.elapsed()
+    );
+}
+
+#[test]
+fn high_frequency_runtime_feed_keeps_every_event_through_a_readonly_flicker() {
+    const WORKERS: usize = 12;
+    const EVENTS_PER_WORKER: usize = 100;
+    const EXPECTED_EVENTS: usize = WORKERS * EVENTS_PER_WORKER;
+
+    let test_started = Instant::now();
+    let db = DirectDbGuard::new();
+    let store = SessionLogStore::open_default().expect("store");
+    let nonce = uuid::Uuid::new_v4().to_string();
+    let workspace = db.workspace(&format!("runtime-feed-{nonce}"));
+    let session_id = format!("runtime-feed-session-{nonce}");
+    let runtime_id = format!("runtime-feed-runtime-{nonce}");
+    let lease_id = format!("runtime-feed-lease-{nonce}");
+    typed_session::create_in_store(
+        &store,
+        &session_id,
+        &workspace,
+        "High-frequency runtime feed",
+        1,
+        TaskPlan::default(),
+    )
+    .expect("create feed session");
+    store
+        .register_runtime(RegisterRuntimeRequest {
+            runtime_id: runtime_id.clone(),
+            session_id: session_id.clone(),
+            fallback_from_id: None,
+        })
+        .expect("register runtime");
+    store
+        .activate_runtime_lease(ActivateRuntimeLeaseRequest {
+            runtime_id: runtime_id.clone(),
+            lease_id: lease_id.clone(),
+        })
+        .expect("activate runtime lease");
+
+    #[cfg(windows)]
+    let readonly_release = {
+        let database_path = Path::new(&workspace)
+            .join(".tura")
+            .join("session_log.sqlite3");
+        let mut permissions = std::fs::metadata(&database_path)
+            .expect("workspace database metadata")
+            .permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&database_path, permissions)
+            .expect("start brief read-only flicker");
+        Some(std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(150));
+            let mut permissions = std::fs::metadata(&database_path)
+                .expect("workspace database metadata")
+                .permissions();
+            permissions.set_readonly(false);
+            std::fs::set_permissions(&database_path, permissions)
+                .expect("finish brief read-only flicker");
+        }))
+    };
+
+    let barrier = Arc::new(Barrier::new(WORKERS));
+    let mut workers = Vec::with_capacity(WORKERS);
+    for worker_index in 0..WORKERS {
+        let store = store.clone();
+        let barrier = Arc::clone(&barrier);
+        let session_id = session_id.clone();
+        let runtime_id = runtime_id.clone();
+        let lease_id = lease_id.clone();
+        workers.push(std::thread::spawn(move || {
+            barrier.wait();
+            for event_index in 0..EVENTS_PER_WORKER {
+                let sequence = worker_index * EVENTS_PER_WORKER + event_index;
+                let outcome = store
+                    .append_session_feed_event(AppendSessionFeedEventRequest {
+                        runtime_id: runtime_id.clone(),
+                        target_session_id: session_id.clone(),
+                        lease_id: lease_id.clone(),
+                        event_id: format!("{runtime_id}:pressure:{sequence}"),
+                        event: SessionFeedEvent::ToolCallUpdated {
+                            message_id: format!("{runtime_id}.message"),
+                            part_id: format!("{runtime_id}.tool.{sequence}"),
+                            tool_name: "pressure_probe".to_string(),
+                            call_id: format!("pressure-{sequence}"),
+                            state: serde_json::json!({
+                                "status": "completed",
+                                "sequence": sequence,
+                            }),
+                            metadata: None,
+                            runtime_status: None,
+                            context_tokens: None,
+                            usage: None,
+                            command_updates: Vec::new(),
+                            created_at: sequence as i64,
+                            updated_at: sequence as i64,
+                        },
+                    })
+                    .expect("append high-frequency runtime feed event");
+                assert!(
+                    matches!(outcome, SessionFeedAppendOutcome::Applied { .. }),
+                    "event {sequence} was not applied: {outcome:?}"
+                );
+            }
+        }));
+    }
+
+    for worker in workers {
+        join_thread_with_timeout(
+            worker,
+            remaining_timeout(test_started, TEST_TIMEOUT, "high-frequency runtime feed"),
+            "high-frequency runtime feed worker",
+        );
+    }
+    #[cfg(windows)]
+    if let Some(release) = readonly_release {
+        release.join().expect("release read-only flicker");
+    }
+
+    let mut cursor = 0_u64;
+    let mut runtime_events = 0_usize;
+    loop {
+        let (entries, next_cursor) = store
+            .read_session_feed(ReadSessionFeedRequest {
+                session_id: session_id.clone(),
+                after_cursor: cursor,
+                limit: 1_000,
+            })
+            .expect("read high-frequency runtime feed");
+        runtime_events += entries
+            .iter()
+            .filter(|entry| entry.runtime_id.as_deref() == Some(runtime_id.as_str()))
+            .filter(|entry| entry.event_id.contains(":pressure:"))
+            .count();
+        if entries.is_empty() {
+            break;
+        }
+        assert!(next_cursor > cursor, "feed cursor must advance");
+        cursor = next_cursor;
+    }
+    assert_eq!(runtime_events, EXPECTED_EVENTS);
+    assert!(
+        test_started.elapsed() < TEST_TIMEOUT,
+        "high-frequency runtime feed took {:?}",
+        test_started.elapsed()
     );
 }
 


### PR DESCRIPTION
## Pull request type

Choose one primary type. If the change needs more focused questions, use the matching template in
[PULL_REQUEST_TEMPLATE/](https://github.com/Tura-AI/tura/tree/main/.github/PULL_REQUEST_TEMPLATE):

- [x] [Bug fix](https://github.com/Tura-AI/tura/compare?expand=1&template=bug_fix.md)
- [ ] [Feature or behavior change](https://github.com/Tura-AI/tura/compare?expand=1&template=feature.md)
- [ ] [Performance or efficiency claim](https://github.com/Tura-AI/tura/compare?expand=1&template=performance.md)
- [ ] [Provider compatibility](https://github.com/Tura-AI/tura/compare?expand=1&template=provider.md)
- [ ] [Documentation only](https://github.com/Tura-AI/tura/compare?expand=1&template=documentation.md)
- [ ] Maintenance or other

## Outcome

Start with the result a user or maintainer can observe, and link the issue when
required. Then explain why the change is no larger than it needs to be.

## Scope and compatibility

- Changed contracts, state, storage, protocol, CLI, GUI, TUI, or installation behavior:
- Compatibility or migration risk:
- Explicitly out of scope:

## Verification

List the exact commands and summarized results. Name any skipped **affected** OS,
surface, provider/protocol, behavior, or state cells and why. Do not enumerate
unaffected combinations.

```text
command -> result
```

## Type-specific evidence

Complete only what applies:

- Bug: reproduction, root cause, and smallest owning regression layer.
- Feature: current user problem and observable acceptance criteria.
- Performance: claim plus the benchmark fields in the
  [contribution guide](https://github.com/Tura-AI/tura/blob/main/docs/contributing-guide.md#performance-and-efficiency-evidence).
- Provider: protocol fixture/live boundary and external dependency metadata.
- Documentation: owning sources checked and links/rendering verified.

If stable automation was not possible, explain why and give the durable
substitute evidence.

## Safety and responsibility

- [x] No credentials, private session data, unsafe provider logs, or generated local state are included.
- [x] Public evidence was sanitized according to the
      [contribution guide](https://github.com/Tura-AI/tura/blob/main/docs/contributing-guide.md#safe-and-reproducible-evidence).
- [x] A human is the primary submitter and accepts responsibility for correctness, licensing, provenance, verification, and the statements in this pull request.
- [x] I have the right to submit all included code, data, prompts, fixtures, and generated material under the repository license.

Meaningful tool or AI assistance, if useful to reviewers (optional):
