### PR TITLE
ci: add manual npm install smoke tests

### DIFF
--- a/.github/workflows/npm-install-linux.yml
+++ b/.github/workflows/npm-install-linux.yml
@@ -1,0 +1,70 @@
+name: NPM Install Linux
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  npm-install:
+    name: npm install Linux (${{ matrix.install-mode }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        install-mode:
+          - global
+          - local
+
+    steps:
+      - name: Node setup
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          package-manager-cache: false
+
+      - name: Record environment
+        shell: bash
+        run: |
+          set -euxo pipefail
+          uname -a
+          node --version
+          npm --version
+          npm view tura-ai version --registry https://registry.npmjs.org/
+
+      - name: Test npm install tura-ai -g
+        if: matrix.install-mode == 'global'
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p "$RUNNER_TEMP/tura-global/npm-prefix"
+          export npm_config_prefix="$RUNNER_TEMP/tura-global/npm-prefix"
+          export PATH="$npm_config_prefix/bin:$PATH"
+          npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
+          command -v tura
+          tura doctor-cli-path
+          npm list -g tura-ai --depth=1
+
+      - name: Test npm install tura-ai
+        if: matrix.install-mode == 'local'
+        shell: bash
+        run: |
+          set -o pipefail
+          install_dir="$RUNNER_TEMP/tura-local"
+          mkdir -p "$install_dir"
+          cd "$install_dir"
+          npm init -y >/dev/null
+          npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
+          test -x ./node_modules/.bin/tura
+          ./node_modules/.bin/tura doctor-cli-path
+          npm list tura-ai --depth=1
+
+      - name: Upload npm install log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: npm-install-linux-${{ matrix.install-mode }}-log
+          path: ${{ runner.temp }}/npm-install-${{ matrix.install-mode }}.log
+          if-no-files-found: warn

--- a/.github/workflows/npm-install-macos.yml
+++ b/.github/workflows/npm-install-macos.yml
@@ -1,0 +1,71 @@
+name: NPM Install macOS
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  npm-install:
+    name: npm install macOS (${{ matrix.install-mode }})
+    runs-on: macos-15
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        install-mode:
+          - global
+          - local
+
+    steps:
+      - name: Node setup
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          package-manager-cache: false
+
+      - name: Record environment
+        shell: bash
+        run: |
+          set -euxo pipefail
+          uname -a
+          sw_vers
+          node --version
+          npm --version
+          npm view tura-ai version --registry https://registry.npmjs.org/
+
+      - name: Test npm install tura-ai -g
+        if: matrix.install-mode == 'global'
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p "$RUNNER_TEMP/tura-global/npm-prefix"
+          export npm_config_prefix="$RUNNER_TEMP/tura-global/npm-prefix"
+          export PATH="$npm_config_prefix/bin:$PATH"
+          npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
+          command -v tura
+          tura doctor-cli-path
+          npm list -g tura-ai --depth=1
+
+      - name: Test npm install tura-ai
+        if: matrix.install-mode == 'local'
+        shell: bash
+        run: |
+          set -o pipefail
+          install_dir="$RUNNER_TEMP/tura-local"
+          mkdir -p "$install_dir"
+          cd "$install_dir"
+          npm init -y >/dev/null
+          npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
+          test -x ./node_modules/.bin/tura
+          ./node_modules/.bin/tura doctor-cli-path
+          npm list tura-ai --depth=1
+
+      - name: Upload npm install log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: npm-install-macos-${{ matrix.install-mode }}-log
+          path: ${{ runner.temp }}/npm-install-${{ matrix.install-mode }}.log
+          if-no-files-found: warn

--- a/.github/workflows/npm-install-matrix.yml
+++ b/.github/workflows/npm-install-matrix.yml
@@ -2,58 +2,27 @@ name: NPM Install Matrix
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - ".github/workflows/npm-install-matrix.yml"
-      - "agents/src/**"
-      - "personas/src/**"
-      - "crates/runtime/src/runtime_prompt/**"
-      - "npm/**"
-      - "scripts/install.ps1"
-      - "scripts/install.sh"
-      - "scripts/npm/**"
-      - "scripts/tests/scripts/test-install.ps1"
-      - "scripts/tests/scripts/test-install.sh"
-      - "package.json"
-      - "README.md"
-      - "scripts/ARCHITECTURE.md"
   push:
     branches:
-      - "codex/**"
-      - "fix/**"
+      - "codex/macos-npm-install-ci"
     paths:
       - ".github/workflows/npm-install-matrix.yml"
-      - "agents/src/**"
-      - "personas/src/**"
-      - "crates/runtime/src/runtime_prompt/**"
-      - "npm/**"
-      - "scripts/install.ps1"
-      - "scripts/install.sh"
-      - "scripts/npm/**"
-      - "scripts/tests/scripts/test-install.ps1"
-      - "scripts/tests/scripts/test-install.sh"
-      - "package.json"
-      - "README.md"
-      - "scripts/ARCHITECTURE.md"
 
 permissions:
   contents: read
 
 jobs:
-  npm-install:
-    name: npm install ${{ matrix.label }}
-    runs-on: ${{ matrix.runner }}
+  npm-install-macos:
+    name: npm install macos-15 (${{ matrix.install-mode }})
+    runs-on: macos-15
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - label: ubuntu-latest
-            runner: ubuntu-latest
-          - label: macos-15
-            runner: macos-15
-          - label: windows-2022
-            runner: windows-2022
+        install-mode:
+          - global
+          - local
+
     steps:
       - uses: actions/checkout@v4
 
@@ -62,31 +31,47 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Run npm installer regression tests
-        id: npm_install
-        shell: pwsh
-        continue-on-error: true
+      - name: Record environment
+        shell: bash
         run: |
-          $ErrorActionPreference = "Continue"
-          New-Item -ItemType Directory -Path .ci-results -Force | Out-Null
-          node --test scripts/npm/cli-path.test.mjs scripts/npm/install-release.test.mjs scripts/npm/release-artifacts.test.mjs 2>&1 | Tee-Object -FilePath ".ci-results/npm-install-${{ matrix.label }}.log"
-          $testExit = $LASTEXITCODE
-          if ($testExit -eq 0) {
-            node scripts/npm/verify-npm-install-fixture.mjs 2>&1 | Tee-Object -FilePath ".ci-results/npm-install-${{ matrix.label }}.log" -Append
-            $testExit = $LASTEXITCODE
-          }
-          "exit_code=$testExit" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          if ($testExit -ne 0) { exit $testExit }
+          set -euxo pipefail
+          uname -a
+          sw_vers
+          node --version
+          npm --version
+          npm view tura-ai version --registry https://registry.npmjs.org/
 
-      - name: Upload npm install logs
+      - name: Test npm install tura-ai -g
+        if: matrix.install-mode == 'global'
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p "$RUNNER_TEMP/tura-global/npm-prefix"
+          export npm_config_prefix="$RUNNER_TEMP/tura-global/npm-prefix"
+          export PATH="$npm_config_prefix/bin:$PATH"
+          npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
+          command -v tura
+          tura doctor-cli-path
+          npm list -g tura-ai --depth=1
+
+      - name: Test npm install tura-ai
+        if: matrix.install-mode == 'local'
+        shell: bash
+        run: |
+          set -o pipefail
+          install_dir="$RUNNER_TEMP/tura-local"
+          mkdir -p "$install_dir"
+          cd "$install_dir"
+          npm init -y >/dev/null
+          npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
+          test -x ./node_modules/.bin/tura
+          ./node_modules/.bin/tura doctor-cli-path
+          npm list tura-ai --depth=1
+
+      - name: Upload npm install log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: npm-install-${{ matrix.label }}-logs
-          path: .ci-results/npm-install-${{ matrix.label }}.log
+          name: npm-install-macos-15-${{ matrix.install-mode }}-log
+          path: ${{ runner.temp }}/npm-install-${{ matrix.install-mode }}.log
           if-no-files-found: warn
-
-      - name: Fail if npm install verification failed
-        if: steps.npm_install.outcome != 'success'
-        shell: pwsh
-        run: exit 1

--- a/.github/workflows/npm-install-matrix.yml
+++ b/.github/workflows/npm-install-matrix.yml
@@ -2,27 +2,58 @@ name: NPM Install Matrix
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "codex/macos-npm-install-ci"
+  pull_request:
     paths:
       - ".github/workflows/npm-install-matrix.yml"
+      - "agents/src/**"
+      - "personas/src/**"
+      - "crates/runtime/src/runtime_prompt/**"
+      - "npm/**"
+      - "scripts/install.ps1"
+      - "scripts/install.sh"
+      - "scripts/npm/**"
+      - "scripts/tests/scripts/test-install.ps1"
+      - "scripts/tests/scripts/test-install.sh"
+      - "package.json"
+      - "README.md"
+      - "scripts/ARCHITECTURE.md"
+  push:
+    branches:
+      - "codex/**"
+      - "fix/**"
+    paths:
+      - ".github/workflows/npm-install-matrix.yml"
+      - "agents/src/**"
+      - "personas/src/**"
+      - "crates/runtime/src/runtime_prompt/**"
+      - "npm/**"
+      - "scripts/install.ps1"
+      - "scripts/install.sh"
+      - "scripts/npm/**"
+      - "scripts/tests/scripts/test-install.ps1"
+      - "scripts/tests/scripts/test-install.sh"
+      - "package.json"
+      - "README.md"
+      - "scripts/ARCHITECTURE.md"
 
 permissions:
   contents: read
 
 jobs:
-  npm-install-macos:
-    name: npm install macos-15 (${{ matrix.install-mode }})
-    runs-on: macos-15
+  npm-install:
+    name: npm install ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        install-mode:
-          - global
-          - local
-
+        include:
+          - label: ubuntu-latest
+            runner: ubuntu-latest
+          - label: macos-15
+            runner: macos-15
+          - label: windows-2022
+            runner: windows-2022
     steps:
       - uses: actions/checkout@v4
 
@@ -31,47 +62,31 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Record environment
-        shell: bash
+      - name: Run npm installer regression tests
+        id: npm_install
+        shell: pwsh
+        continue-on-error: true
         run: |
-          set -euxo pipefail
-          uname -a
-          sw_vers
-          node --version
-          npm --version
-          npm view tura-ai version --registry https://registry.npmjs.org/
+          $ErrorActionPreference = "Continue"
+          New-Item -ItemType Directory -Path .ci-results -Force | Out-Null
+          node --test scripts/npm/cli-path.test.mjs scripts/npm/install-release.test.mjs scripts/npm/release-artifacts.test.mjs 2>&1 | Tee-Object -FilePath ".ci-results/npm-install-${{ matrix.label }}.log"
+          $testExit = $LASTEXITCODE
+          if ($testExit -eq 0) {
+            node scripts/npm/verify-npm-install-fixture.mjs 2>&1 | Tee-Object -FilePath ".ci-results/npm-install-${{ matrix.label }}.log" -Append
+            $testExit = $LASTEXITCODE
+          }
+          "exit_code=$testExit" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          if ($testExit -ne 0) { exit $testExit }
 
-      - name: Test npm install tura-ai -g
-        if: matrix.install-mode == 'global'
-        shell: bash
-        run: |
-          set -o pipefail
-          mkdir -p "$RUNNER_TEMP/tura-global/npm-prefix"
-          export npm_config_prefix="$RUNNER_TEMP/tura-global/npm-prefix"
-          export PATH="$npm_config_prefix/bin:$PATH"
-          npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
-          command -v tura
-          tura doctor-cli-path
-          npm list -g tura-ai --depth=1
-
-      - name: Test npm install tura-ai
-        if: matrix.install-mode == 'local'
-        shell: bash
-        run: |
-          set -o pipefail
-          install_dir="$RUNNER_TEMP/tura-local"
-          mkdir -p "$install_dir"
-          cd "$install_dir"
-          npm init -y >/dev/null
-          npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
-          test -x ./node_modules/.bin/tura
-          ./node_modules/.bin/tura doctor-cli-path
-          npm list tura-ai --depth=1
-
-      - name: Upload npm install log
+      - name: Upload npm install logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: npm-install-macos-15-${{ matrix.install-mode }}-log
-          path: ${{ runner.temp }}/npm-install-${{ matrix.install-mode }}.log
+          name: npm-install-${{ matrix.label }}-logs
+          path: .ci-results/npm-install-${{ matrix.label }}.log
           if-no-files-found: warn
+
+      - name: Fail if npm install verification failed
+        if: steps.npm_install.outcome != 'success'
+        shell: pwsh
+        run: exit 1

--- a/.github/workflows/npm-install-windows.yml
+++ b/.github/workflows/npm-install-windows.yml
@@ -1,0 +1,82 @@
+name: NPM Install Windows
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  npm-install:
+    name: npm install Windows (${{ matrix.install-mode }})
+    runs-on: windows-2022
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        install-mode:
+          - global
+          - local
+
+    steps:
+      - name: Node setup
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          package-manager-cache: false
+
+      - name: Record environment
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Get-ComputerInfo | Select-Object WindowsProductName, WindowsVersion, OsArchitecture
+          node --version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm --version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm view tura-ai version --registry https://registry.npmjs.org/
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Test npm install tura-ai -g
+        if: matrix.install-mode == 'global'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $prefix = Join-Path $env:RUNNER_TEMP "tura-global\npm-prefix"
+          New-Item -ItemType Directory -Path $prefix -Force | Out-Null
+          $env:npm_config_prefix = $prefix
+          $env:Path = "$prefix;$env:Path"
+          npm install tura-ai -g 2>&1 | Tee-Object -FilePath (Join-Path $env:RUNNER_TEMP "npm-install-global.log")
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Get-Command tura
+          tura doctor-cli-path
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm list -g tura-ai --depth=1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Test npm install tura-ai
+        if: matrix.install-mode == 'local'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installDir = Join-Path $env:RUNNER_TEMP "tura-local"
+          New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+          Set-Location $installDir
+          npm init -y | Out-Null
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm install tura-ai 2>&1 | Tee-Object -FilePath (Join-Path $env:RUNNER_TEMP "npm-install-local.log")
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $tura = Join-Path $installDir "node_modules\.bin\tura.cmd"
+          if (-not (Test-Path -LiteralPath $tura)) { throw "Local tura command was not installed: $tura" }
+          & $tura doctor-cli-path
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm list tura-ai --depth=1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload npm install log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: npm-install-windows-${{ matrix.install-mode }}-log
+          path: ${{ runner.temp }}\npm-install-${{ matrix.install-mode }}.log
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

- add a manual Linux npm install workflow
- add a manual macOS npm install workflow
- add a manual Windows npm install workflow
- test both `npm install tura-ai -g` and `npm install tura-ai` in separate matrix jobs
- verify the installed CLI path and upload the npm install log

All three workflows use `workflow_dispatch` only, so they do not run automatically.

## Validation

- Prettier YAML parse/format check passed for all three workflow files
- macOS 15 ARM64 smoke run passed for both global and local installs: https://github.com/Tura-AI/tura/actions/runs/31962534002