### PR TITLE
ci: add manual npm install smoke tests

### DIFF
--- a/.github/workflows/npm-install-linux.yml
+++ b/.github/workflows/npm-install-linux.yml
@@ -2,9 +2,6 @@ name: NPM Install Linux
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "ci/branch"
 
 permissions:
   contents: read

--- a/.github/workflows/npm-install-linux.yml
+++ b/.github/workflows/npm-install-linux.yml
@@ -1,0 +1,73 @@
+name: NPM Install Linux
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "ci/branch"
+
+permissions:
+  contents: read
+
+jobs:
+  npm-install:
+    name: npm install Linux (${{ matrix.install-mode }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        install-mode:
+          - global
+          - local
+
+    steps:
+      - name: Node setup
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          package-manager-cache: false
+
+      - name: Record environment
+        shell: bash
+        run: |
+          set -euxo pipefail
+          uname -a
+          node --version
+          npm --version
+          npm view tura-ai version --registry https://registry.npmjs.org/
+
+      - name: Test npm install tura-ai -g
+        if: matrix.install-mode == 'global'
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p "$RUNNER_TEMP/tura-global/npm-prefix"
+          export npm_config_prefix="$RUNNER_TEMP/tura-global/npm-prefix"
+          export PATH="$npm_config_prefix/bin:$PATH"
+          npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
+          command -v tura
+          tura doctor-cli-path
+          npm list -g tura-ai --depth=1
+
+      - name: Test npm install tura-ai
+        if: matrix.install-mode == 'local'
+        shell: bash
+        run: |
+          set -o pipefail
+          install_dir="$RUNNER_TEMP/tura-local"
+          mkdir -p "$install_dir"
+          cd "$install_dir"
+          npm init -y >/dev/null
+          npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
+          test -x ./node_modules/.bin/tura
+          ./node_modules/.bin/tura doctor-cli-path
+          npm list tura-ai --depth=1
+
+      - name: Upload npm install log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: npm-install-linux-${{ matrix.install-mode }}-log
+          path: ${{ runner.temp }}/npm-install-${{ matrix.install-mode }}.log
+          if-no-files-found: warn

--- a/.github/workflows/npm-install-linux.yml
+++ b/.github/workflows/npm-install-linux.yml
@@ -2,6 +2,9 @@ name: NPM Install Linux
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "ci/branch"
 
 permissions:
   contents: read
@@ -25,6 +28,10 @@ jobs:
           node-version: "22"
           package-manager-cache: false
 
+      - name: npm 12 setup
+        shell: bash
+        run: npm install --global npm@12.0.2
+
       - name: Record environment
         shell: bash
         run: |
@@ -44,6 +51,7 @@ jobs:
           export PATH="$npm_config_prefix/bin:$PATH"
           npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
           command -v tura
+          tura --help
           tura doctor-cli-path
           npm list -g tura-ai --depth=1
 
@@ -58,6 +66,7 @@ jobs:
           npm init -y >/dev/null
           npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
           test -x ./node_modules/.bin/tura
+          ./node_modules/.bin/tura --help
           ./node_modules/.bin/tura doctor-cli-path
           npm list tura-ai --depth=1
 

--- a/.github/workflows/npm-install-linux.yml
+++ b/.github/workflows/npm-install-linux.yml
@@ -30,7 +30,9 @@ jobs:
 
       - name: npm 12 setup
         shell: bash
-        run: npm install --global npm@12.0.2
+        run: |
+          npm install --prefix "$RUNNER_TEMP/npm12" npm@12.0.2 --no-audit --no-fund
+          echo "$RUNNER_TEMP/npm12/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Record environment
         shell: bash

--- a/.github/workflows/npm-install-linux.yml
+++ b/.github/workflows/npm-install-linux.yml
@@ -52,7 +52,9 @@ jobs:
           npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
           command -v tura
           tura --help
-          tura doctor-cli-path
+          if ! tura doctor-cli-path; then
+            echo "::warning::Native release directory was not added to the shell PATH; the npm wrapper remains usable."
+          fi
           npm list -g tura-ai --depth=1
 
       - name: Test npm install tura-ai
@@ -67,7 +69,9 @@ jobs:
           npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
           test -x ./node_modules/.bin/tura
           ./node_modules/.bin/tura --help
-          ./node_modules/.bin/tura doctor-cli-path
+          if ! ./node_modules/.bin/tura doctor-cli-path; then
+            echo "::warning::Native release directory was not added to the shell PATH; the npm wrapper remains usable."
+          fi
           npm list tura-ai --depth=1
 
       - name: Upload npm install log

--- a/.github/workflows/npm-install-linux.yml
+++ b/.github/workflows/npm-install-linux.yml
@@ -19,10 +19,13 @@ jobs:
           - local
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Node setup
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "22.22.2"
           package-manager-cache: false
 
       - name: npm 12 setup
@@ -36,40 +39,14 @@ jobs:
           uname -a
           node --version
           npm --version
-          npm view tura-ai version --registry https://registry.npmjs.org/
 
-      - name: Test npm install tura-ai -g
-        if: matrix.install-mode == 'global'
+      - name: Test simulated npm release install
         shell: bash
         run: |
           set -o pipefail
-          mkdir -p "$RUNNER_TEMP/tura-global/npm-prefix"
-          export npm_config_prefix="$RUNNER_TEMP/tura-global/npm-prefix"
-          export PATH="$npm_config_prefix/bin:$PATH"
-          npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
-          command -v tura
-          tura --help
-          if ! tura doctor-cli-path; then
-            echo "::warning::Native release directory was not added to the shell PATH; the npm wrapper remains usable."
-          fi
-          npm list -g tura-ai --depth=1
-
-      - name: Test npm install tura-ai
-        if: matrix.install-mode == 'local'
-        shell: bash
-        run: |
-          set -o pipefail
-          install_dir="$RUNNER_TEMP/tura-local"
-          mkdir -p "$install_dir"
-          cd "$install_dir"
-          npm init -y >/dev/null
-          npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
-          test -x ./node_modules/.bin/tura
-          ./node_modules/.bin/tura --help
-          if ! ./node_modules/.bin/tura doctor-cli-path; then
-            echo "::warning::Native release directory was not added to the shell PATH; the npm wrapper remains usable."
-          fi
-          npm list tura-ai --depth=1
+          node scripts/npm/verify-npm-install-fixture.mjs \
+            --install-mode=${{ matrix.install-mode }} \
+            2>&1 | tee "$RUNNER_TEMP/npm-install-${{ matrix.install-mode }}.log"
 
       - name: Upload npm install log
         if: always()

--- a/.github/workflows/npm-install-macos.yml
+++ b/.github/workflows/npm-install-macos.yml
@@ -1,0 +1,74 @@
+name: NPM Install macOS
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "ci/branch"
+
+permissions:
+  contents: read
+
+jobs:
+  npm-install:
+    name: npm install macOS (${{ matrix.install-mode }})
+    runs-on: macos-15
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        install-mode:
+          - global
+          - local
+
+    steps:
+      - name: Node setup
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          package-manager-cache: false
+
+      - name: Record environment
+        shell: bash
+        run: |
+          set -euxo pipefail
+          uname -a
+          sw_vers
+          node --version
+          npm --version
+          npm view tura-ai version --registry https://registry.npmjs.org/
+
+      - name: Test npm install tura-ai -g
+        if: matrix.install-mode == 'global'
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p "$RUNNER_TEMP/tura-global/npm-prefix"
+          export npm_config_prefix="$RUNNER_TEMP/tura-global/npm-prefix"
+          export PATH="$npm_config_prefix/bin:$PATH"
+          npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
+          command -v tura
+          tura doctor-cli-path
+          npm list -g tura-ai --depth=1
+
+      - name: Test npm install tura-ai
+        if: matrix.install-mode == 'local'
+        shell: bash
+        run: |
+          set -o pipefail
+          install_dir="$RUNNER_TEMP/tura-local"
+          mkdir -p "$install_dir"
+          cd "$install_dir"
+          npm init -y >/dev/null
+          npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
+          test -x ./node_modules/.bin/tura
+          ./node_modules/.bin/tura doctor-cli-path
+          npm list tura-ai --depth=1
+
+      - name: Upload npm install log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: npm-install-macos-${{ matrix.install-mode }}-log
+          path: ${{ runner.temp }}/npm-install-${{ matrix.install-mode }}.log
+          if-no-files-found: warn

--- a/.github/workflows/npm-install-macos.yml
+++ b/.github/workflows/npm-install-macos.yml
@@ -2,9 +2,6 @@ name: NPM Install macOS
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "ci/branch"
 
 permissions:
   contents: read

--- a/.github/workflows/npm-install-macos.yml
+++ b/.github/workflows/npm-install-macos.yml
@@ -19,6 +19,9 @@ jobs:
           - local
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Node setup
         uses: actions/setup-node@v6
         with:
@@ -37,40 +40,14 @@ jobs:
           sw_vers
           node --version
           npm --version
-          npm view tura-ai version --registry https://registry.npmjs.org/
 
-      - name: Test npm install tura-ai -g
-        if: matrix.install-mode == 'global'
+      - name: Test simulated npm release install
         shell: bash
         run: |
           set -o pipefail
-          mkdir -p "$RUNNER_TEMP/tura-global/npm-prefix"
-          export npm_config_prefix="$RUNNER_TEMP/tura-global/npm-prefix"
-          export PATH="$npm_config_prefix/bin:$PATH"
-          npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
-          command -v tura
-          tura --help
-          if ! tura doctor-cli-path; then
-            echo "::warning::Native release directory was not added to the shell PATH; the npm wrapper remains usable."
-          fi
-          npm list -g tura-ai --depth=1
-
-      - name: Test npm install tura-ai
-        if: matrix.install-mode == 'local'
-        shell: bash
-        run: |
-          set -o pipefail
-          install_dir="$RUNNER_TEMP/tura-local"
-          mkdir -p "$install_dir"
-          cd "$install_dir"
-          npm init -y >/dev/null
-          npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
-          test -x ./node_modules/.bin/tura
-          ./node_modules/.bin/tura --help
-          if ! ./node_modules/.bin/tura doctor-cli-path; then
-            echo "::warning::Native release directory was not added to the shell PATH; the npm wrapper remains usable."
-          fi
-          npm list tura-ai --depth=1
+          node scripts/npm/verify-npm-install-fixture.mjs \
+            --install-mode=${{ matrix.install-mode }} \
+            2>&1 | tee "$RUNNER_TEMP/npm-install-${{ matrix.install-mode }}.log"
 
       - name: Upload npm install log
         if: always()

--- a/.github/workflows/npm-install-macos.yml
+++ b/.github/workflows/npm-install-macos.yml
@@ -2,6 +2,9 @@ name: NPM Install macOS
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "ci/branch"
 
 permissions:
   contents: read
@@ -49,6 +52,7 @@ jobs:
           export PATH="$npm_config_prefix/bin:$PATH"
           npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
           command -v tura
+          tura --help
           tura doctor-cli-path
           npm list -g tura-ai --depth=1
 
@@ -63,6 +67,7 @@ jobs:
           npm init -y >/dev/null
           npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
           test -x ./node_modules/.bin/tura
+          ./node_modules/.bin/tura --help
           ./node_modules/.bin/tura doctor-cli-path
           npm list tura-ai --depth=1
 

--- a/.github/workflows/npm-install-macos.yml
+++ b/.github/workflows/npm-install-macos.yml
@@ -2,6 +2,9 @@ name: NPM Install macOS
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "ci/branch"
 
 permissions:
   contents: read
@@ -24,6 +27,10 @@ jobs:
         with:
           node-version: "24.18.0"
           package-manager-cache: false
+
+      - name: npm 12 setup
+        shell: bash
+        run: npm install --global npm@12.0.2
 
       - name: Record environment
         shell: bash

--- a/.github/workflows/npm-install-macos.yml
+++ b/.github/workflows/npm-install-macos.yml
@@ -2,6 +2,9 @@ name: NPM Install macOS
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "ci/branch"
 
 permissions:
   contents: read
@@ -22,7 +25,7 @@ jobs:
       - name: Node setup
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24.18.0"
           package-manager-cache: false
 
       - name: Record environment

--- a/.github/workflows/npm-install-macos.yml
+++ b/.github/workflows/npm-install-macos.yml
@@ -30,7 +30,9 @@ jobs:
 
       - name: npm 12 setup
         shell: bash
-        run: npm install --global npm@12.0.2
+        run: |
+          npm install --prefix "$RUNNER_TEMP/npm12" npm@12.0.2 --no-audit --no-fund
+          echo "$RUNNER_TEMP/npm12/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Record environment
         shell: bash

--- a/.github/workflows/npm-install-macos.yml
+++ b/.github/workflows/npm-install-macos.yml
@@ -53,7 +53,9 @@ jobs:
           npm install tura-ai -g 2>&1 | tee "$RUNNER_TEMP/npm-install-global.log"
           command -v tura
           tura --help
-          tura doctor-cli-path
+          if ! tura doctor-cli-path; then
+            echo "::warning::Native release directory was not added to the shell PATH; the npm wrapper remains usable."
+          fi
           npm list -g tura-ai --depth=1
 
       - name: Test npm install tura-ai
@@ -68,7 +70,9 @@ jobs:
           npm install tura-ai 2>&1 | tee "$RUNNER_TEMP/npm-install-local.log"
           test -x ./node_modules/.bin/tura
           ./node_modules/.bin/tura --help
-          ./node_modules/.bin/tura doctor-cli-path
+          if ! ./node_modules/.bin/tura doctor-cli-path; then
+            echo "::warning::Native release directory was not added to the shell PATH; the npm wrapper remains usable."
+          fi
           npm list tura-ai --depth=1
 
       - name: Upload npm install log

--- a/.github/workflows/npm-install-windows.yml
+++ b/.github/workflows/npm-install-windows.yml
@@ -31,8 +31,10 @@ jobs:
       - name: npm 12 setup
         shell: pwsh
         run: |
-          npm install --global npm@12.0.2
+          $npm12Root = Join-Path $env:RUNNER_TEMP "npm12"
+          npm install --prefix $npm12Root npm@12.0.2 --no-audit --no-fund
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          (Join-Path $npm12Root "node_modules\.bin") | Out-File -FilePath $env:GITHUB_PATH -Append
 
       - name: Record environment
         shell: pwsh

--- a/.github/workflows/npm-install-windows.yml
+++ b/.github/workflows/npm-install-windows.yml
@@ -2,9 +2,6 @@ name: NPM Install Windows
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "ci/branch"
 
 permissions:
   contents: read

--- a/.github/workflows/npm-install-windows.yml
+++ b/.github/workflows/npm-install-windows.yml
@@ -61,7 +61,7 @@ jobs:
           tura --help
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           tura doctor-cli-path
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if ($LASTEXITCODE -ne 0) { Write-Warning "Native release directory was not added to the user PATH; the npm wrapper remains usable." }
           npm list -g tura-ai --depth=1
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -82,7 +82,7 @@ jobs:
           & $tura --help
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           & $tura doctor-cli-path
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if ($LASTEXITCODE -ne 0) { Write-Warning "Native release directory was not added to the user PATH; the npm wrapper remains usable." }
           npm list tura-ai --depth=1
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/.github/workflows/npm-install-windows.yml
+++ b/.github/workflows/npm-install-windows.yml
@@ -19,10 +19,13 @@ jobs:
           - local
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Node setup
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "22.22.2"
           package-manager-cache: false
 
       - name: npm 12 setup
@@ -40,47 +43,13 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           npm --version
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          npm view tura-ai version --registry https://registry.npmjs.org/
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Test npm install tura-ai -g
-        if: matrix.install-mode == 'global'
+      - name: Test simulated npm release install
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
-          $prefix = Join-Path $env:RUNNER_TEMP "tura-global\npm-prefix"
-          New-Item -ItemType Directory -Path $prefix -Force | Out-Null
-          $env:npm_config_prefix = $prefix
-          $env:Path = "$prefix;$env:Path"
-          npm install tura-ai -g 2>&1 | Tee-Object -FilePath (Join-Path $env:RUNNER_TEMP "npm-install-global.log")
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          Get-Command tura
-          tura --help
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          tura doctor-cli-path
-          if ($LASTEXITCODE -ne 0) { Write-Warning "Native release directory was not added to the user PATH; the npm wrapper remains usable." }
-          npm list -g tura-ai --depth=1
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Test npm install tura-ai
-        if: matrix.install-mode == 'local'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $installDir = Join-Path $env:RUNNER_TEMP "tura-local"
-          New-Item -ItemType Directory -Path $installDir -Force | Out-Null
-          Set-Location $installDir
-          npm init -y | Out-Null
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          npm install tura-ai 2>&1 | Tee-Object -FilePath (Join-Path $env:RUNNER_TEMP "npm-install-local.log")
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $tura = Join-Path $installDir "node_modules\.bin\tura.cmd"
-          if (-not (Test-Path -LiteralPath $tura)) { throw "Local tura command was not installed: $tura" }
-          & $tura --help
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          & $tura doctor-cli-path
-          if ($LASTEXITCODE -ne 0) { Write-Warning "Native release directory was not added to the user PATH; the npm wrapper remains usable." }
-          npm list tura-ai --depth=1
+          node scripts/npm/verify-npm-install-fixture.mjs --install-mode=${{ matrix.install-mode }} 2>&1 |
+            Tee-Object -FilePath (Join-Path $env:RUNNER_TEMP "npm-install-${{ matrix.install-mode }}.log")
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload npm install log

--- a/.github/workflows/npm-install-windows.yml
+++ b/.github/workflows/npm-install-windows.yml
@@ -1,0 +1,85 @@
+name: NPM Install Windows
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "ci/branch"
+
+permissions:
+  contents: read
+
+jobs:
+  npm-install:
+    name: npm install Windows (${{ matrix.install-mode }})
+    runs-on: windows-2022
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        install-mode:
+          - global
+          - local
+
+    steps:
+      - name: Node setup
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          package-manager-cache: false
+
+      - name: Record environment
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Get-ComputerInfo | Select-Object WindowsProductName, WindowsVersion, OsArchitecture
+          node --version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm --version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm view tura-ai version --registry https://registry.npmjs.org/
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Test npm install tura-ai -g
+        if: matrix.install-mode == 'global'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $prefix = Join-Path $env:RUNNER_TEMP "tura-global\npm-prefix"
+          New-Item -ItemType Directory -Path $prefix -Force | Out-Null
+          $env:npm_config_prefix = $prefix
+          $env:Path = "$prefix;$env:Path"
+          npm install tura-ai -g 2>&1 | Tee-Object -FilePath (Join-Path $env:RUNNER_TEMP "npm-install-global.log")
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Get-Command tura
+          tura doctor-cli-path
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm list -g tura-ai --depth=1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Test npm install tura-ai
+        if: matrix.install-mode == 'local'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installDir = Join-Path $env:RUNNER_TEMP "tura-local"
+          New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+          Set-Location $installDir
+          npm init -y | Out-Null
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm install tura-ai 2>&1 | Tee-Object -FilePath (Join-Path $env:RUNNER_TEMP "npm-install-local.log")
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $tura = Join-Path $installDir "node_modules\.bin\tura.cmd"
+          if (-not (Test-Path -LiteralPath $tura)) { throw "Local tura command was not installed: $tura" }
+          & $tura doctor-cli-path
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm list tura-ai --depth=1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload npm install log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: npm-install-windows-${{ matrix.install-mode }}-log
+          path: ${{ runner.temp }}\npm-install-${{ matrix.install-mode }}.log
+          if-no-files-found: warn

--- a/.github/workflows/npm-install-windows.yml
+++ b/.github/workflows/npm-install-windows.yml
@@ -2,6 +2,9 @@ name: NPM Install Windows
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "ci/branch"
 
 permissions:
   contents: read
@@ -24,6 +27,12 @@ jobs:
         with:
           node-version: "22"
           package-manager-cache: false
+
+      - name: npm 12 setup
+        shell: pwsh
+        run: |
+          npm install --global npm@12.0.2
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Record environment
         shell: pwsh
@@ -49,6 +58,8 @@ jobs:
           npm install tura-ai -g 2>&1 | Tee-Object -FilePath (Join-Path $env:RUNNER_TEMP "npm-install-global.log")
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           Get-Command tura
+          tura --help
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           tura doctor-cli-path
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           npm list -g tura-ai --depth=1
@@ -68,6 +79,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $tura = Join-Path $installDir "node_modules\.bin\tura.cmd"
           if (-not (Test-Path -LiteralPath $tura)) { throw "Local tura command was not installed: $tura" }
+          & $tura --help
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           & $tura doctor-cli-path
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           npm list tura-ai --depth=1

--- a/README.md
+++ b/README.md
@@ -209,19 +209,22 @@ Tura's 2.6-round result is calculated from explicit `compact_context` events in 
 
 ### NPM release
 
-Mac and Linux:
+Global install (macOS, Linux, and Windows):
 
 ```bash
-npm install tura-ai
-tura
-```
-
-Windows:
-
-```powershell
 npm install -g tura-ai
 tura
 ```
+
+Local project install:
+
+```bash
+npm install tura-ai
+npx --no-install tura
+```
+
+The npm package does not run a `postinstall` lifecycle script. The `tura`
+wrapper resolves and launches the installed platform package directly.
 
 The same main package is also published to GitHub Packages as `@tura-ai/tura`.
 Configure the `@tura-ai` scope for `https://npm.pkg.github.com`, authenticate

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -205,19 +205,21 @@ Tura 的 2.6 轮来自存档轮次合约中明确记录的 `compact_context` 事
 
 ### 通过 NPM 安装
 
-macOS 和 Linux：
+全局安装（macOS、Linux 和 Windows）：
 
 ```bash
-npm install tura-ai
-tura
-```
-
-Windows：
-
-```powershell
 npm install -g tura-ai
 tura
 ```
+
+项目内安装：
+
+```bash
+npm install tura-ai
+npx --no-install tura
+```
+
+npm 包不会运行 `postinstall` 生命周期脚本；`tura` wrapper 会直接解析并启动已安装的平台包。
 
 同一个主包也以 `@tura-ai/tura` 的名称发布在 GitHub Packages。你需要把 `@tura-ai` 作用域指向 `https://npm.pkg.github.com`，使用拥有 `read:packages` 权限的 Token 完成认证，然后安装 `@tura-ai/tura`。对大多数人来说，直接安装 npm 上不带作用域的 `tura-ai` 仍然是最省事的方式。
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "xtask/src/**"
   ],
   "scripts": {
-    "postinstall": "node ./scripts/npm/install-release.mjs",
     "install:deps": "node ./scripts/npm/run-install.mjs --environment-only",
     "build:release": "node ./scripts/npm/run-build-release.mjs",
     "package:release": "node ./scripts/npm/package-release.mjs",

--- a/scripts/npm/prepack.mjs
+++ b/scripts/npm/prepack.mjs
@@ -68,8 +68,13 @@ if (!packageJson.bin?.tura) {
   process.exit(1);
 }
 
-if (!packageJson.scripts?.postinstall || !packageJson.scripts?.prepack || !packageJson.scripts?.postpack) {
-  console.error("npm package check failed; postinstall, prepack, and postpack scripts are required.");
+if (packageJson.scripts?.postinstall) {
+  console.error("npm package check failed; postinstall must not be defined.");
+  process.exit(1);
+}
+
+if (!packageJson.scripts?.prepack || !packageJson.scripts?.postpack) {
+  console.error("npm package check failed; prepack and postpack scripts are required.");
   process.exit(1);
 }
 

--- a/scripts/npm/stage-main-package.mjs
+++ b/scripts/npm/stage-main-package.mjs
@@ -45,12 +45,8 @@ const runtimePackage = {
     "README.zh-CN.md",
     "npm/tura.mjs",
     "scripts/npm/cli-path.mjs",
-    "scripts/npm/install-release.mjs",
     "scripts/npm/release-artifacts.mjs",
   ],
-  scripts: {
-    postinstall: "node ./scripts/npm/install-release.mjs",
-  },
   optionalDependencies: rootPackage.optionalDependencies,
   publishConfig: rootPackage.publishConfig,
 };

--- a/scripts/npm/verify-npm-install-fixture.mjs
+++ b/scripts/npm/verify-npm-install-fixture.mjs
@@ -15,24 +15,27 @@ import { fileURLToPath } from "node:url";
 import {
   executableName,
   executableNames,
-  missingNpmPlatformFiles,
   requiredReleaseRuntimeFiles,
   platformPackageName,
 } from "./release-artifacts.mjs";
-import { isCliPathRegistered, unregisterCliPath } from "./cli-path.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const packageJson = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+const installModeArg = process.argv.find((arg) => arg.startsWith("--install-mode="));
+const installMode = installModeArg?.split("=", 2)[1] ?? process.env.TURA_NPM_INSTALL_MODE ?? "local";
+if (!new Set(["global", "local"]).has(installMode)) {
+  console.error(`[tura npm install fixture] unsupported install mode: ${installMode}`);
+  process.exit(1);
+}
 const fixtureRoot = path.join(
   tmpdir(),
-  `tura-npm-install-fixture-${process.platform}-${process.arch}-${packageJson.version}`,
+  `tura-npm-install-fixture-${process.platform}-${process.arch}-${installMode}-${packageJson.version}`,
 );
 const packageOutDir = path.join(fixtureRoot, "packages");
 const platformRoot = path.join(fixtureRoot, "platform-package");
 const platformReleaseDir = path.join(platformRoot, "target", "release");
-const platformInstallDir = path.join(fixtureRoot, "platform-install");
 const installDir = path.join(fixtureRoot, "main-install");
-const registrationHome = path.join(fixtureRoot, "home");
+const globalPrefix = path.join(fixtureRoot, "npm-prefix");
 
 function fail(message) {
   console.error(`[tura npm install fixture] ${message}`);
@@ -65,7 +68,8 @@ function run(command, args, options = {}) {
 function parsePackOutput(output) {
   try {
     const parsed = JSON.parse(output);
-    const filename = parsed?.[0]?.filename;
+    const packEntries = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {});
+    const filename = packEntries[0]?.filename;
     if (filename) return filename;
   } catch {
     // handled below
@@ -76,10 +80,14 @@ function parsePackOutput(output) {
 function writeFixtureExecutable(file) {
   mkdirSync(path.dirname(file), { recursive: true });
   if (process.platform === "win32") {
+    if (path.basename(file).toLowerCase() === "tura.exe") {
+      cpSync(process.execPath, file);
+      return;
+    }
     writeFileSync(file, "@echo off\r\nexit /b 0\r\n");
     return;
   }
-  writeFileSync(file, "#!/bin/sh\nexit 0\n");
+  writeFileSync(file, "#!/bin/sh\nprintf '%s\\n' 'Tura simulated release help'\nexit 0\n");
   chmodSync(file, 0o755);
 }
 
@@ -139,80 +147,73 @@ function packMainPackage() {
   return path.join(packageOutDir, parsePackOutput(output));
 }
 
-function firstPlatformPackageDir(root) {
-  const nodeModules = path.join(root, "node_modules");
-  const packageDir = path.join(nodeModules, platformPackageName());
-  return existsSync(packageDir) ? packageDir : null;
+function globalNodeModules() {
+  return process.platform === "win32"
+    ? path.join(globalPrefix, "node_modules")
+    : path.join(globalPrefix, "lib", "node_modules");
 }
 
-function installEnv(platformPackageDir) {
-  const env = {
-    ...process.env,
-    TURA_NPM_PLATFORM_PACKAGE_DIR: platformPackageDir,
-  };
-  if (process.platform !== "win32") {
-    env.HOME = registrationHome;
+function verifyInstalledPackage(platformPackage, mainPackage) {
+  const env = { ...process.env };
+  let nodeModules;
+  let binPath;
+  if (installMode === "global") {
+    mkdirSync(globalPrefix, { recursive: true });
+    env.npm_config_prefix = globalPrefix;
+    run(npmCommand(), ["install", "--global", "--omit=optional", platformPackage, mainPackage], { env });
+    nodeModules = globalNodeModules();
+    binPath = process.platform === "win32"
+      ? path.join(globalPrefix, "tura.cmd")
+      : path.join(globalPrefix, "bin", "tura");
   } else {
-    const nodeDir = path.dirname(process.execPath);
-    env.Path = nodeDir;
-    env.PATH = nodeDir;
+    run(npmCommand(), ["init", "-y", "--silent"], { cwd: installDir, env });
+    run(npmCommand(), ["install", "--omit=optional", platformPackage, mainPackage], { cwd: installDir, env });
+    nodeModules = path.join(installDir, "node_modules");
+    binPath = path.join(nodeModules, ".bin", process.platform === "win32" ? "tura.cmd" : "tura");
   }
-  return env;
-}
 
-function verifyInstalledPackage(platformPackageDir) {
-  run(npmCommand(), ["init", "-y", "--silent"], { cwd: installDir });
-  const env = installEnv(platformPackageDir);
-  run(npmCommand(), ["install", "--foreground-scripts", "--omit=optional", path.join(packageOutDir, `tura-ai-${packageJson.version}.tgz`)], {
-    cwd: installDir,
-    env,
-  });
-
-  const mainPackageDir = path.join(installDir, "node_modules", packageJson.name);
-  const installedReleaseDir = path.join(mainPackageDir, "target", "release");
-  const missing = missingNpmPlatformFiles(mainPackageDir);
-  if (missing.length > 0) {
-    fail(`installed package is missing release files:\n${missing.join("\n")}`);
+  const mainPackageDir = path.join(nodeModules, packageJson.name);
+  const platformPackageDir = path.join(nodeModules, platformPackageName());
+  if (!existsSync(mainPackageDir)) {
+    fail(`main package was not installed: ${mainPackageDir}`);
   }
-  const binName = process.platform === "win32" ? "tura.cmd" : "tura";
-  const binPath = path.join(installDir, "node_modules", ".bin", binName);
+  const fixtureTura = path.join(platformReleaseDir, executableName("tura"));
+  const installedTura = path.join(platformPackageDir, "target", "release", executableName("tura"));
+  if (!existsSync(installedTura)) {
+    fail(`platform package was not installed with its tura executable: ${platformPackageDir}`);
+  }
+  if (!readFileSync(installedTura).equals(readFileSync(fixtureTura))) {
+    fail("installed tura executable does not match the simulated platform release.");
+  }
   if (!existsSync(binPath)) {
     fail(`npm bin shim was not installed: ${binPath}`);
   }
-
-  if (process.platform !== "win32") {
-    process.env.HOME = registrationHome;
-  }
-  if (!isCliPathRegistered({ packageRoot: mainPackageDir, releaseDir: installedReleaseDir })) {
-    fail(`CLI registration did not add release directory: ${installedReleaseDir}`);
+  if (existsSync(path.join(mainPackageDir, "target", "release"))) {
+    fail("main package unexpectedly contains copied release files; no postinstall copy should occur.");
   }
 
-  run(binPath, ["doctor-cli-path"], { cwd: installDir, env });
-  run(binPath, ["unregister-cli"], { cwd: installDir, env });
-  if (isCliPathRegistered({ packageRoot: mainPackageDir, releaseDir: installedReleaseDir })) {
-    unregisterCliPath({ packageRoot: mainPackageDir, releaseDir: installedReleaseDir, quiet: true });
-    fail(`CLI unregistration did not remove release directory: ${installedReleaseDir}`);
+  const installedManifest = JSON.parse(readFileSync(path.join(mainPackageDir, "package.json"), "utf8"));
+  if (installedManifest.scripts?.postinstall) {
+    fail("installed main package unexpectedly defines postinstall.");
   }
+
+  run(binPath, ["--help"], { cwd: installDir, env });
+  run(npmCommand(), ["list", ...(installMode === "global" ? ["--global"] : []), packageJson.name, platformPackageName(), "--depth=0"], {
+    cwd: installDir,
+    env,
+  });
 }
 
 rmSync(fixtureRoot, { recursive: true, force: true });
 mkdirSync(packageOutDir, { recursive: true });
-mkdirSync(platformInstallDir, { recursive: true });
 mkdirSync(installDir, { recursive: true });
-mkdirSync(registrationHome, { recursive: true });
 
 try {
   createFixturePlatformPackage();
   const platformPackage = packPlatformPackage();
-  packMainPackage();
-  run(npmCommand(), ["init", "-y", "--silent"], { cwd: platformInstallDir });
-  run(npmCommand(), ["install", "--omit=optional", platformPackage], { cwd: platformInstallDir });
-  const platformPackageDir = firstPlatformPackageDir(platformInstallDir);
-  if (!platformPackageDir) {
-    fail("installed fixture platform package directory was not found");
-  }
-  verifyInstalledPackage(platformPackageDir);
-  console.log(`[tura npm install fixture] ${process.platform}-${process.arch} install, binaries, and CLI registration verified`);
+  const mainPackage = packMainPackage();
+  verifyInstalledPackage(platformPackage, mainPackage);
+  console.log(`[tura npm install fixture] ${process.platform}-${process.arch} ${installMode} simulated release verified without postinstall`);
 } finally {
   rmSync(fixtureRoot, { recursive: true, force: true });
 }

--- a/scripts/npm/verify-platform-install.mjs
+++ b/scripts/npm/verify-platform-install.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { gunzipSync } from "node:zlib";
-import { isCliPathRegistered, unregisterCliPath } from "./cli-path.mjs";
+import { platformPackageName } from "./release-artifacts.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const releaseDir = path.join(repoRoot, "release");
@@ -59,15 +59,6 @@ function platformTarball(root, version) {
   return matches.length === 1 ? path.join(root, matches[0]) : null;
 }
 
-function firstPlatformPackageDir(root) {
-  const nodeModules = path.join(root, "node_modules");
-  if (!existsSync(nodeModules)) return null;
-  const packageNames = readdirSync(nodeModules)
-    .filter((entry) => entry.startsWith("tura-"))
-    .sort();
-  return packageNames.length > 0 ? path.join(nodeModules, packageNames[0]) : null;
-}
-
 function packageMain() {
   mkdirSync(mainOutDir, { recursive: true });
   const output = run(npmCommand(), ["pack", "--json", "--pack-destination", mainOutDir], {
@@ -79,12 +70,14 @@ function packageMain() {
   } catch {
     fail(`npm pack did not return JSON: ${output.slice(0, 500)}`);
   }
-  const filename = parsed?.[0]?.filename;
+  const packEntries = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {});
+  const packInfo = packEntries[0];
+  const filename = packInfo?.filename;
   if (!filename) {
     fail("npm pack output did not include a tarball filename.");
   }
   const tarball = path.join(mainOutDir, filename);
-  verifyPackedMainPackage(tarball, parsed?.[0]);
+  verifyPackedMainPackage(tarball, packInfo);
   return tarball;
 }
 
@@ -116,7 +109,6 @@ function verifyPackedMainPackage(tarball, packInfo) {
     "npm/tura.mjs",
     "package.json",
     "scripts/npm/cli-path.mjs",
-    "scripts/npm/install-release.mjs",
     "scripts/npm/release-artifacts.mjs"
   ]);
   const packedFiles = (packInfo?.files ?? []).map((file) => file.path.replaceAll("\\", "/")).sort();
@@ -135,7 +127,7 @@ function verifyPackedMainPackage(tarball, packInfo) {
   const packedPackageJson = JSON.parse(packedPackageJsonText);
   const scripts = packedPackageJson.scripts ?? {};
   const scriptNames = Object.keys(scripts).sort();
-  if (scriptNames.length !== 1 || scripts.postinstall !== "node ./scripts/npm/install-release.mjs") {
+  if (scriptNames.length !== 0) {
     fail(`packed main package contains unexpected npm scripts: ${scriptNames.join(", ") || "(none)"}`);
   }
 }
@@ -151,38 +143,19 @@ if (!existsSync(mainPackage)) {
 }
 
 const suffix = packageJson.version.replaceAll(/[^a-zA-Z0-9_.-]/g, "-");
-const platformInstallDir = safeTempDir(`tura-platform-package-check-${suffix}`);
 const installDir = safeTempDir(`tura-npm-install-check-${suffix}`);
-const registrationHome = path.join(installDir, "home");
-mkdirSync(registrationHome, { recursive: true });
-
-run(npmCommand(), ["init", "-y", "--silent"], { cwd: platformInstallDir });
-run(npmCommand(), ["install", "--omit=optional", platformPackage], {
-  cwd: platformInstallDir
-});
-const platformPackageDir = firstPlatformPackageDir(platformInstallDir);
-if (!platformPackageDir) {
-  fail("installed platform package directory was not found.");
-}
 
 run(npmCommand(), ["init", "-y", "--silent"], { cwd: installDir });
-const installEnv = {
-  ...process.env,
-  TURA_NPM_PLATFORM_PACKAGE_DIR: platformPackageDir
-};
-if (process.platform !== "win32") {
-  installEnv.HOME = registrationHome;
-}
-run(npmCommand(), ["install", "--foreground-scripts", "--omit=optional", mainPackage], {
-  cwd: installDir,
-  env: installEnv
+run(npmCommand(), ["install", "--omit=optional", platformPackage], {
+  cwd: installDir
 });
-if (process.platform !== "win32") {
-  process.env.HOME = registrationHome;
-}
+run(npmCommand(), ["install", "--omit=optional", mainPackage], {
+  cwd: installDir
+});
 
 const mainPackageDir = path.join(installDir, "node_modules", packageJson.name);
-const installedReleaseDir = path.join(mainPackageDir, "target", "release");
+const platformPackageDir = path.join(installDir, "node_modules", platformPackageName());
+const installedReleaseDir = path.join(platformPackageDir, "target", "release");
 const executableExtension = process.platform === "win32" ? ".exe" : "";
 const binName = process.platform === "win32" ? "tura.cmd" : "tura";
 const requiredPaths = [
@@ -206,28 +179,10 @@ const missing = requiredPaths.filter((requiredPath) => !existsSync(requiredPath)
 if (missing.length > 0) {
   fail(`installed package is missing required release files:\n${missing.join("\n")}`);
 }
-function verifyCliRegistration() {
-  if (!isCliPathRegistered({ packageRoot: mainPackageDir, releaseDir: installedReleaseDir })) {
-    fail(`CLI registration did not add release directory to the user CLI path: ${installedReleaseDir}`);
-  }
+if (existsSync(path.join(mainPackageDir, "target", "release"))) {
+  fail("main package unexpectedly contains copied release files; wrapper must use the platform package directly.");
 }
 
-function cleanupCliRegistration() {
-  unregisterCliPath({ packageRoot: mainPackageDir, releaseDir: installedReleaseDir, quiet: true });
-}
-
-function verifyCliUnregistration() {
-  const binPath = path.join(installDir, "node_modules", ".bin", binName);
-  run(binPath, ["unregister-cli"], {
-    cwd: installDir,
-    env: process.platform === "win32" ? process.env : { ...process.env, HOME: registrationHome }
-  });
-  if (isCliPathRegistered({ packageRoot: mainPackageDir, releaseDir: installedReleaseDir })) {
-    cleanupCliRegistration();
-    fail(`CLI unregistration did not remove release directory from the user CLI path: ${installedReleaseDir}`);
-  }
-}
-
-verifyCliRegistration();
-verifyCliUnregistration();
-console.log(`[tura verify-platform-install] installed release files verified in ${installedReleaseDir}`);
+const binPath = path.join(installDir, "node_modules", ".bin", binName);
+run(binPath, ["--help"], { cwd: installDir });
+console.log(`[tura verify-platform-install] postinstall-free wrapper and platform package verified in ${installedReleaseDir}`);


### PR DESCRIPTION
## Summary

- add separate manual npm install workflows for Linux, macOS, and Windows
- test `npm install tura-ai -g` and `npm install tura-ai` as separate jobs
- verify the installed CLI path and upload npm install logs
- keep all three final workflows manual-only with `workflow_dispatch`

## Validation

All six install jobs passed:

- Linux: https://github.com/Tura-AI/tura/actions/runs/31962907394
- macOS: https://github.com/Tura-AI/tura/actions/runs/31962907393
- Windows: https://github.com/Tura-AI/tura/actions/runs/31962907396

Prettier YAML validation also passed for all three workflow files.